### PR TITLE
Calculate rest if task had update on last day

### DIFF
--- a/apps/client/src/app/core/database/services/energy.service.spec.ts
+++ b/apps/client/src/app/core/database/services/energy.service.spec.ts
@@ -140,4 +140,18 @@ describe("EnergyService", () => {
 
     expect(service.getEnergyUpdate(reset, completionEntry, energy, task, entry).amount).toBe(30);
   });
+
+  it("should not update energy if task was completed yesterday", () => {
+    const reset = 1652004000;
+    const oneDayBefore = reset + 3600000 - 86400000;
+    const completionEntry: CompletionEntry = {
+      amount: 2,
+      updated: oneDayBefore
+    };
+    const energy = { $key: "test", data: {}, updated: oneDayBefore };
+    const task = tasks[0]; // Chaos dungeon
+    const entry = { amount: 40 };
+
+    expect(service.getEnergyUpdate(reset, completionEntry, energy, task, entry).amount).toBe(40);
+  });
 });

--- a/apps/client/src/app/core/database/services/energy.service.ts
+++ b/apps/client/src/app/core/database/services/energy.service.ts
@@ -53,7 +53,7 @@ export class EnergyService extends FirestoreStorage<Energy> {
                   const entry = getCompletionEntry(energy.data, character, task) || {
                     amount: 0
                   };
-                  if (completionEntry && (reset - completionEntry.updated) > 86400000) {
+                  if (completionEntry) {
                     setCompletionEntry(energy.data, character, task, this.getEnergyUpdate(reset, completionEntry, energy, task, entry));
                   } else if (!completionEntry && !newEnergy) {
                     setCompletionEntry(energy.data, character, task, { amount: 0 });


### PR DESCRIPTION
The goal is to be able to update partial energy completion. It should update once and energy.lastupdate would be after reset time, making it update only once