### PR TITLE
Add a way to relink a gearset with another character

### DIFF
--- a/apps/client/src/app/pages/gearsets/gear-manager/gear-manager.component.html
+++ b/apps/client/src/app/pages/gearsets/gear-manager/gear-manager.component.html
@@ -14,7 +14,8 @@
         </ng-template>
         <nz-select [(ngModel)]="gearset.character"
                    class="character-selector"
-                   nzPlaceHolder="You can link this gearset to a character">
+                   nzPlaceHolder="You can link this gearset to a character"
+                   (ngModelChange)="updateLink(gearset)">
           <nz-option *ngFor="let character of roster.characters" [nzLabel]="character.name" nzValue="{{roster.$key}}:{{character.id}}"></nz-option>
         </nz-select>
       </nz-input-group>

--- a/apps/client/src/app/pages/gearsets/gear-manager/gear-manager.component.ts
+++ b/apps/client/src/app/pages/gearsets/gear-manager/gear-manager.component.ts
@@ -221,6 +221,10 @@ export class GearManagerComponent {
     ).subscribe();
   }
 
+  updateLink(gearset: Gearset): void {
+    this.gearsetService.updateOne(gearset.$key, {character: gearset.character})
+  }
+
   updateIlvl(gearset: Gearset, roster: Roster): void {
     const updated = {
       ...roster, characters: roster.characters.map(c => {


### PR DESCRIPTION
If you accidently created a gearset and linked it to the wrong character, you never can update it again.

This feature saves the selection when changed and updates the link.