### PR TITLE
Hide characters of friends which are not applicable for Oreha

### DIFF
--- a/apps/client/src/app/pages/party-planner/party-planner/party-planner.component.ts
+++ b/apps/client/src/app/pages/party-planner/party-planner/party-planner.component.ts
@@ -49,7 +49,7 @@ export class PartyPlannerComponent {
               ...task,
               subTask: child,
               minIlvl: child.minIlvl,
-              maxIlvl: taskChildren[i + 1]?.minIlvl - 1 || 9999
+              maxIlvl: child.maxIlvl || taskChildren[i + 1]?.minIlvl - 1 || 9999
             } as LostarkTaskWithSubtask;
           });
         })

--- a/apps/client/src/app/pages/party-planner/subtask.ts
+++ b/apps/client/src/app/pages/party-planner/subtask.ts
@@ -3,5 +3,6 @@ export interface Subtask {
   name: string;
   parentName: string;
   minIlvl: number;
+  maxIlvl?: number;
   banner?: string;
 }

--- a/apps/client/src/app/pages/party-planner/subtasks.ts
+++ b/apps/client/src/app/pages/party-planner/subtasks.ts
@@ -29,9 +29,9 @@ export const subtasks: Subtask[] = [
 
   // T3 Abyss
   { id: `aira's-oculus-normal`, name: `Aira's Oculus (Normal)`, parentName: "Aira's Oculus", banner: "abyss_dungeons/abyss_dg_09.png", minIlvl: 1325 },
-  { id: `aira's-oculus-hard`, name: `Aira's Oculus (Hard)`, parentName: "Aira's Oculus", banner: "abyss_dungeons/abyss_dg_09.png", minIlvl: 1370 },
+  { id: `aira's-oculus-hard`, name: `Aira's Oculus (Hard)`, parentName: "Aira's Oculus", banner: "abyss_dungeons/abyss_dg_09.png", minIlvl: 1370, maxIlvl: 1415 },
   { id: `oreha-preveza-normal`, name: `Oreha Preveza (Normal)`, parentName: "Oreha Preveza", banner: "abyss_dungeons/abyss_dg_10.png", minIlvl: 1340 },
-  { id: `oreha-preveza-hard`, name: `Oreha Preveza (Hard)`, parentName: "Oreha Preveza", banner: "abyss_dungeons/abyss_dg_10.png", minIlvl: 1370 },
+  { id: `oreha-preveza-hard`, name: `Oreha Preveza (Hard)`, parentName: "Oreha Preveza", banner: "abyss_dungeons/abyss_dg_10.png", minIlvl: 1370, maxIlvl: 1415 },
 
   // Argos Phases
   { id: `argos-p1`, name: `Argos P1`, parentName: "Argos", banner: "abyss_raids/abyss_02.png", minIlvl: 1370 },


### PR DESCRIPTION
Not sure if bug or intended, but characters above 1415 do not get any gold from Oreha, but are still listed on the party planer.

I know these characters can still help them, but you are not able to mark it as done.

So even if I helped someone with my main >1415, it still shows up to all my friends, because I can't mark it as done.

I think the best thing would be to just hide them as its done on the checklist.