### PR TITLE
Fixing export and import in tasks and roster

### DIFF
--- a/apps/client/src/app/pages/roster/roster/roster.component.ts
+++ b/apps/client/src/app/pages/roster/roster/roster.component.ts
@@ -145,11 +145,14 @@ export class RosterComponent {
     }).afterClose
       .pipe(
         filter(json => {
-          return json && Array.isArray(JSON.parse(json));
+          const parsed = JSON.parse(json);
+          const hasCharacters = Array.isArray( parsed.characters ) && parsed.characters.length > 0;
+          return json && hasCharacters;
         }),
         withLatestFrom(this.auth.uid$),
         switchMap(([rosterJson, uid]) => {
-          return this.rosterService.updateOne(uid, { characters: JSON.parse(rosterJson) });
+          const parsed = JSON.parse(rosterJson);
+          return this.rosterService.updateOne(uid, { characters: parsed.characters, trackedTasks: {} });
         })
       )
       .subscribe({

--- a/apps/client/src/app/pages/tasks/tasks/tasks.component.html
+++ b/apps/client/src/app/pages/tasks/tasks/tasks.component.html
@@ -6,9 +6,11 @@
       <button nz-button (click)="exportTasks(tasks)" nz-tooltip nzTooltipTitle="Export custom tasks">
         <i nz-icon nzType="upload" nzTheme="outline"></i>
       </button>
-      <button nz-button (click)="importTasks()" nz-tooltip nzTooltipTitle="Import custom tasks">
-        <i nz-icon nzType="download" nzTheme="outline"></i>
-      </button>
+      <ng-container *ngIf="uid$ | async as uid">
+        <button nz-button (click)="importTasks(uid)" nz-tooltip nzTooltipTitle="Import custom tasks">
+          <i nz-icon nzType="download" nzTheme="outline"></i>
+        </button>
+      </ng-container>
     </nz-page-header-extra>
   </nz-page-header>
   <nz-card nzTitle="Tasks">

--- a/apps/client/src/app/pages/tasks/tasks/tasks.component.ts
+++ b/apps/client/src/app/pages/tasks/tasks/tasks.component.ts
@@ -156,11 +156,12 @@ export class TasksComponent {
   }
 
   exportTasks(tasks: LostarkTask[]): void {
-    this.clipboard.copy(JSON.stringify(tasks.map(t => t.custom)));
+    console.log(tasks);
+    this.clipboard.copy(JSON.stringify(tasks.filter(t => t.custom)));
     this.message.success("Custom tasks copied to your clipboard");
   }
 
-  importTasks(): void {
+  importTasks(uid: string): void {
     this.modal.create({
       nzTitle: "Import tasks",
       nzContent: TextQuestionPopupComponent,
@@ -174,7 +175,9 @@ export class TasksComponent {
       )
       .subscribe((tasksJson) => {
         try {
-          this.tasksService.importTasks(JSON.parse(tasksJson || "[]"));
+          const parsed=  JSON.parse(tasksJson || "[]");
+          const tasks = parsed.map((task: LostarkTask) => ({ ...task, authorId: uid, custom: true }));
+          this.tasksService.importTasks(tasks);
           this.message.success("Custom tasks imported");
         } catch (e: unknown) {
           this.message.error((e as Error).message);


### PR DESCRIPTION
Today, the `import` action for Roster and `export/import` for Tasks are broken.

For roster, the problem is that we export the entire `roster` collection, but use only`.characters` at import action.

For tasks, we're exporting only the `.custom` flag because we're mapping instead of filtering the tasks, and we need to force a new `authorId` at import.