### PR TITLE
Add automatic CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,3 +17,6 @@ jobs:
         run: npm install
       - name: Build & Deploy
         run: npx nx deploy
+        env:
+          #FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,8 +14,8 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@master
       - name: Install Dependencies
-        run: npm install
+        run: yarn install
       - name: Build & Deploy
-        run: npx nx deploy
+        run: ng deploy
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,6 @@ jobs:
       - name: Install Dependencies
         run: yarn install
       - name: Build & Deploy
-        run: ng deploy
+        run: npx nx deploy
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,5 +18,4 @@ jobs:
       - name: Build & Deploy
         run: npx nx deploy
         env:
-          #FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
-          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,17 @@
+name: Build and Deploy
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@master
+      - name: Install Dependencies
+        run: npm install
+      - name: Build & Deploy
+        run: npm run deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,9 +9,11 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
+      - name: Install Dependencies
+        run: npm install -g firebase-tools
       - name: Checkout Repo
         uses: actions/checkout@master
       - name: Install Dependencies
         run: npm install
       - name: Build & Deploy
-        run: npm run deploy
+        run: npx nx deploy


### PR DESCRIPTION
This is a easy way to automatic deploy when pushing to master.

To get it working, there needs to be secret (https://github.com/Supamiu/Lostark-helper/settings/secrets/actions) with the name: `FIREBASE_TOKEN`

The value can be generated using the firebase-cli: `firebase login:ci`

It says its deprecated but works at the moment. I tried with a service account, but didn't get it working together with `@angular/fire:deploy`

Do we want to have a separate branch `release`, so we can first freely merge to `master` and decide when to release?