### PR TITLE
Add max level for argos

### DIFF
--- a/apps/client/src/app/core/tasks.ts
+++ b/apps/client/src/app/core/tasks.ts
@@ -75,7 +75,7 @@ export const tasks = [
     shared: true,
     partySize: 4
   }),
-  createTask(`Argos`, 1370, TaskFrequency.WEEKLY, TaskScope.CHARACTER, 1, 9999, "abyssal-raid.webp", {
+  createTask(`Argos`, 1370, TaskFrequency.WEEKLY, TaskScope.CHARACTER, 1, 1475, "abyssal-raid.webp", {
     shared: true,
     partySize: 8
   }),

--- a/apps/client/src/app/model/lostark-task.ts
+++ b/apps/client/src/app/model/lostark-task.ts
@@ -3,7 +3,7 @@ import { TaskScope } from "./task-scope";
 import { DataModel } from "../core/database/data-model";
 
 
-export const TASKS_VERSION = 32;
+export const TASKS_VERSION = 33;
 
 export interface LostarkTask extends DataModel {
   authorId?: string;

--- a/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.ts
+++ b/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.ts
@@ -105,7 +105,7 @@ export class GoldPlannerComponent {
             if (cantDoTask || ilvlTooLow || ilvlTooHigh) {
               if (!forceFlag) {
                 return {
-                  force: gTask.canForce ? false : null,
+                  force: gTask.canForce && !ilvlTooHigh ? false : null,
                   value: null
                 };
               }

--- a/apps/client/src/app/pages/gold-planner/gold-tasks.ts
+++ b/apps/client/src/app/pages/gold-planner/gold-tasks.ts
@@ -112,6 +112,7 @@ export const goldTasks: GoldTask[] = [
     taskName: "Argos",
     chestPrice: 300,
     completionId: "T3.1",
+    overrideMaxIlvl: 1475,
     chestId: "Argos"
   },
   {
@@ -122,6 +123,7 @@ export const goldTasks: GoldTask[] = [
     completionId: "T3.1",
     chestId: "Argos",
     overrideMinIlvl: 1385,
+    overrideMaxIlvl: 1475,
     canForce: true
   },
   {
@@ -132,6 +134,7 @@ export const goldTasks: GoldTask[] = [
     completionId: "T3.1",
     chestId: "Argos",
     overrideMinIlvl: 1400,
+    overrideMaxIlvl: 1475,
     canForce: true
   },
 


### PR DESCRIPTION
Do not merge yet! This is a suspected change but we do not have patch notes yet.

This adds a max level (1475) for argos.

Also I'm not sure if the change in `apps/client/src/app/core/tasks.ts` is enough or do we have to manually fix that task in the firebase DB?