### PR TITLE
Updated stuff in Gold Planner

### DIFF
--- a/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.html
+++ b/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.html
@@ -61,7 +61,7 @@
             <td nzLeft nzWidth="300px">Chaos Dungeons</td>
             <td class="manual-row" *ngFor="let character of roster">
               <nz-input-group [nzAddOnBefore]="goldIcon">
-                <nz-input-number [ngModel]="display.chaos[character.name]" (ngModelChange)="setManualGold(settings.$key, 'chaos', character.name, $event)" [ngModelOptions]="{updateOn: 'blur'}"></nz-input-number>
+                <nz-input-number [nzFormatter]="manualGoldFormatter" [ngModel]="display.chaos[character.name]" (ngModelChange)="setManualGold(settings.$key, 'chaos', character.name, $event)" [ngModelOptions]="{updateOn: 'blur'}"></nz-input-number>
               </nz-input-group>
             </td>
           </tr>
@@ -69,7 +69,7 @@
             <td nzLeft nzWidth="300px">Other sources  <i nz-icon nzType="message" nzTheme="outline" nz-tooltip nzTooltipTitle="For buses costs you can put negative values like (-1300)"  class="info-icon"></i></td>
             <td class="manual-row" *ngFor="let character of roster">
               <nz-input-group [nzAddOnBefore]="goldIcon">
-                <nz-input-number [ngModel]="display.other[character.name]" (ngModelChange)="setManualGold(settings.$key, 'other', character.name, $event)" pattern="[1-9].*" [ngModelOptions]="{updateOn: 'blur'}"></nz-input-number>
+                <nz-input-number [nzFormatter]="manualGoldFormatter" [ngModel]="display.other[character.name]" (ngModelChange)="setManualGold(settings.$key, 'other', character.name, $event)" [ngModelOptions]="{updateOn: 'blur'}"></nz-input-number>
               </nz-input-group>
             </td>
           </tr>

--- a/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.ts
+++ b/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.ts
@@ -235,11 +235,8 @@ export class GoldPlannerComponent {
   }
 
   public setManualGold(settingsKey: string, type: string, characterName: string, newValue: number): void {
-    if (typeof newValue === 'string') {
-      return;
-    }
     this.settings.updateOne(settingsKey, {
-      [`manualGoldEntries.${type}:${characterName}`]: { amount: newValue || 0, timestamp: Date.now() }
+      [`manualGoldEntries.${type}:${characterName}`]: { amount: this.manualGoldFormatter(newValue) || 0, timestamp: Date.now() }
     } as unknown as UpdateData<Settings>);
   }
 
@@ -262,4 +259,12 @@ export class GoldPlannerComponent {
   trackByIndex(index: number): number {
     return index;
   }
+
+  manualGoldFormatter(value: number | string): number {
+    if(!value || typeof value === 'string' ) {
+      return 0;
+    }
+    
+    return Math.floor(value);
+  };
 }

--- a/apps/client/src/app/pages/gold-planner/gold-tasks.ts
+++ b/apps/client/src/app/pages/gold-planner/gold-tasks.ts
@@ -113,7 +113,7 @@ export const goldTasks: GoldTask[] = [
     chestPrice: 300,
     completionId: "T3.1",
     overrideMaxIlvl: 1475,
-    chestId: "Argos"
+    chestId: "Argos1"
   },
   {
     name: "Argos P2",
@@ -121,10 +121,8 @@ export const goldTasks: GoldTask[] = [
     taskName: "Argos",
     chestPrice: 300,
     completionId: "T3.1",
-    chestId: "Argos",
-    overrideMinIlvl: 1385,
+    chestId: "Argos2",
     overrideMaxIlvl: 1475,
-    canForce: true
   },
   {
     name: "Argos P3",
@@ -132,10 +130,8 @@ export const goldTasks: GoldTask[] = [
     taskName: "Argos",
     chestPrice: 500,
     completionId: "T3.1",
-    chestId: "Argos",
-    overrideMinIlvl: 1400,
+    chestId: "Argos3",
     overrideMaxIlvl: 1475,
-    canForce: true
   },
 
   // T3 Legion Raid

--- a/apps/client/src/app/pages/party-planner/subtasks.ts
+++ b/apps/client/src/app/pages/party-planner/subtasks.ts
@@ -35,8 +35,8 @@ export const subtasks: Subtask[] = [
 
   // Argos Phases
   { id: `argos-p1`, name: `Argos P1`, parentName: "Argos", banner: "abyss_raids/abyss_02.png", minIlvl: 1370 },
-  { id: `argos-p2`, name: `Argos P2`, parentName: "Argos", banner: "abyss_raids/abyss_02.png", minIlvl: 1385 },
-  { id: `argos-p3`, name: `Argos P3`, parentName: "Argos", banner: "abyss_raids/abyss_02.png", minIlvl: 1400 },
+  { id: `argos-p2`, name: `Argos P2`, parentName: "Argos", banner: "abyss_raids/abyss_02.png", minIlvl: 1370 },
+  { id: `argos-p3`, name: `Argos P3`, parentName: "Argos", banner: "abyss_raids/abyss_02.png", minIlvl: 1370 },
 
   // Valtan Difficulties
   { id: `valtan-normal`, name: `Valtan Normal`, parentName: "Valtan", minIlvl: 1415 },


### PR DESCRIPTION
1. Updated Argos gold planner to be able to claim for individual gates (11-16-2022 patch)
2. Added formatter for manual gold inputs
   - to handle whole numbers only
   - revert to default 0 when its empty or invalid