### PR TITLE
fix gearset ilvl calculations for ancient gear over 20 honing level

### DIFF
--- a/apps/client/src/app/core/services/honing.service.ts
+++ b/apps/client/src/app/core/services/honing.service.ts
@@ -102,9 +102,21 @@ export class HoningService {
     } else if (gearPiece.rarity <= GearsetRarity.RELIC) {
       honingIlvlBonus = Math.min(gearPiece.honing, 15) * 5
         + Math.max(gearPiece.honing - 15, 0) * 15;
-    } else {
+    } else if (gearPiece.rarity <= GearsetRarity.UPPER_RELIC) {
       honingIlvlBonus = Math.min(gearPiece.honing, 10) * 10
         + Math.max(gearPiece.honing - 10, 0) * 10;
+    } else {
+      let higherThanTwentyIlvlBonus = 0;
+      let lowerThanTwentyIlvlBonus = 0;
+      if (gearPiece.honing <= 20) {
+        lowerThanTwentyIlvlBonus = Math.max(gearPiece.honing - 10, 0) * 10;
+      }
+      if (gearPiece.honing > 20) {
+        higherThanTwentyIlvlBonus = 100 + (Math.max(gearPiece.honing - 20, 0) * 5);
+      }
+      honingIlvlBonus = Math.min(gearPiece.honing, 10) * 10
+        + lowerThanTwentyIlvlBonus
+        + higherThanTwentyIlvlBonus;
     }
     return baseIlvl + honingIlvlBonus;
   }


### PR DESCRIPTION
Noticed this bug when testing it out on live site. The issue:

When selecting honing levels for ancient gear above 20, the calculation was off because it was still doing the bonus ilvl calculations by 10 instead of 5, as ancient gear goes up by 5 ilvls per hone after 20 instead of 10 between 6-20.

Updated the math for ancient gear to calculate depending on the honing level of the item. If it's below or equal to 20, it will do the multiplication by 10. If it's above 20, it will do the multiplication by 5 and then add 100 for the first 20 levels. The total bonus is then added together to give the accurate ilvl of the gear piece.

This will need additional changes when Akkan gear comes out and GearsetRarity.UPPER_ANCIENT is added.