### PR TITLE
Decluttered the Party Planner visually

### DIFF
--- a/apps/client/src/app/pages/party-planner/party-planner/party-planner.component.html
+++ b/apps/client/src/app/pages/party-planner/party-planner/party-planner.component.html
@@ -103,20 +103,18 @@
             <td *ngFor="let task of row.data" class="with-inner-table"
                 [class.completed]="task.done === -1 || task.done >= task.task.amount"
                 [class.even]="even"
-                [class.daily]="task.task.frequency == TaskFrequency.DAILY"
-                [class.weekly]="task.task.frequency == TaskFrequency.WEEKLY">
+                [class.daily]="task.task.frequency === TaskFrequency.DAILY"
+                [class.weekly]="task.task.frequency === TaskFrequency.WEEKLY">
               <div class="task-friends" *ngIf="task.friends?.length > 0">
                 <div *ngFor="let friend of task.friends" class="task-friend-container">
                   <div class="friend-name">{{friend.friendId | userName | async}}</div>
                   <div class="friend-characters">
                     <div nz-col nzOffset="7" nzSpan="10" class="center">
-                      <nz-select nzPlaceHolder="Characters" nzShowSearch nzAllowClear class="select" nzSize="large" (ngModelChange)="onChangeSecond($event)" [(ngModel)]="second">
+                      <nz-select nzPlaceHolder="Characters" nzShowSearch nzAllowClear>
                           <nz-option *ngFor="let fc of friend.characters" class="friend-character" [nzValue]="row.id" [nzLabel]="row.name">
                             <div nz-tooltip nzTooltipTitle="You can do {{fc.doable}} runs together">
                               ({{fc.doable}})
                             </div>
-                            <img src="./assets/icons/classes/class_{{fc.c.class?.toString()?.padStart(2,'0')}}.png" alt=""
-                               class="class-icon" *ngIf="fc.c.class !== null">
                           </nz-option>
                       </nz-select>
                     </div>

--- a/apps/client/src/app/pages/party-planner/party-planner/party-planner.component.html
+++ b/apps/client/src/app/pages/party-planner/party-planner/party-planner.component.html
@@ -39,8 +39,6 @@
             {{character.name}} [{{character.ilvl}}]
             <i nz-icon nzType="message" nzTheme="outline" *ngIf="character.note"
                nz-tooltip [nzTooltipTitle]="character.note" class="note-icon"></i>
-            <i nz-icon nzType="clock-circle" nzTheme="outline" *ngIf="character.lazy"
-               nz-tooltip nzTooltipTitle="Only resets after 3 days"></i>
           </div>
         </th>
       </tr>
@@ -111,17 +109,16 @@
                 <div *ngFor="let friend of task.friends" class="task-friend-container">
                   <div class="friend-name">{{friend.friendId | userName | async}}</div>
                   <div class="friend-characters">
-                    <div *ngFor="let fc of friend.characters" class="friend-character">
-                      <img src="./assets/icons/classes/class_{{fc.c.class?.toString()?.padStart(2,'0')}}.png" alt=""
-                           class="class-icon" *ngIf="fc.c.class !== null">
-                      <div nz-tooltip nzTooltipTitle="ilvl {{fc.c.ilvl}}">{{fc.c.name}}</div>&nbsp;
-                      <div nz-tooltip nzTooltipTitle="You can do {{fc.doable}} runs together">
-                        ({{fc.doable}})
-                      </div>
-                      <div *ngIf="fc.c.lazy" class="lazy-icon">
-                        <i nz-icon nzType="clock-circle" nzTheme="outline"
-                           nz-tooltip nzTooltipTitle="Only resets after 3 days"></i>
-                      </div>
+                    <div nz-col nzOffset="7" nzSpan="10" class="center">
+                      <nz-select nzPlaceHolder="Characters" nzShowSearch nzAllowClear class="select" nzSize="large" (ngModelChange)="onChangeSecond($event)" [(ngModel)]="second">
+                          <nz-option *ngFor="let fc of friend.characters" class="friend-character" [nzValue]="row.id" [nzLabel]="row.name">
+                            <div nz-tooltip nzTooltipTitle="You can do {{fc.doable}} runs together">
+                              ({{fc.doable}})
+                            </div>
+                            <img src="./assets/icons/classes/class_{{fc.c.class?.toString()?.padStart(2,'0')}}.png" alt=""
+                               class="class-icon" *ngIf="fc.c.class !== null">
+                          </nz-option>
+                      </nz-select>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
Huge fan of the helper, however all my friends (a good handful of 10+) and I, while we gravely attempt to use it, find it very painful to use the Party Planner feature as it tends to look increasingly cluttered and deters us away. Especially with multiple friends added. 

In this PR, I cleaned it visually up: it now displays the available friends with the available content and to see the characters the friends have, it's now displayed as a drop-down to de-clutter the visuals. 