### PR TITLE
Party planner unusable with large roster

### DIFF
--- a/apps/client/src/app/pages/party-planner/party-planner/party-planner.component.ts
+++ b/apps/client/src/app/pages/party-planner/party-planner/party-planner.component.ts
@@ -234,7 +234,7 @@ export class PartyPlannerComponent {
             y: `${window.innerHeight - 64 - 48 - 180}px`
           };
           if (roster.characters.length > 8) {
-            scroll.x = `${window.innerWidth - 80 - 48}px`;
+            scroll.x = `${window.innerWidth + roster.characters.length * 80}px`;
           }
           return scroll;
         })


### PR DESCRIPTION
Related issue: https://github.com/Supamiu/Lostark-helper/issues/111

fix: scale table width with roster length

![party planner large roster](https://github.com/Supamiu/Lostark-helper/assets/52977737/95c94ba4-c898-47fa-9750-299689ddf512)
