### PR TITLE
Gold planner rework

### DIFF
--- a/apps/client/src/app/core/database/services/settings.service.ts
+++ b/apps/client/src/app/core/database/services/settings.service.ts
@@ -13,13 +13,14 @@ export class SettingsService extends FirestoreStorage<Settings> {
     switchMap(uid => {
       return this.getOne(uid).pipe(
         switchMap(settings => {
-          if (settings.notFound || Object.keys(settings).length < 6) {
+          if (settings.notFound || Object.keys(settings).length < 7) {
             const result = {
               ...settings,
               hiddenOnCompletion: false,
               crystallineAura: true,
               lazytracking: {},
               chestConfiguration: {},
+              goldPlannerConfiguration: {},
               forceAbyss: {}
             };
             return this.setOne(uid, result).pipe(

--- a/apps/client/src/app/model/settings.ts
+++ b/apps/client/src/app/model/settings.ts
@@ -12,5 +12,7 @@ export interface Settings extends DataModel {
   manualGoldEntries: Record<string, ManualWeeklyGoldEntry>;
   // True = skip chest, False = take chest
   chestConfiguration: Record<string, boolean>;
+    // True = skip gold, False = take gold
+  goldPlannerConfiguration: Record<string, boolean>;
   forceAbyss: Record<string, boolean>;
 }

--- a/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.html
+++ b/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.html
@@ -60,12 +60,12 @@
               </td>
             </tr>
           </ng-container>
-          <tr>
+          <!-- <tr>
             <td nzLeft nzWidth="300px">Large Gold Chest(s) - (<img src="./assets/icons/gold.png"
               class="gold-icon" alt="gold">{{display.chestGold | number}})</td>
             <td [attr.colspan]="display.total.length" class="roster-income">
             </td>
-          </tr>
+          </tr> -->
           <tr>
             <td nzLeft nzWidth="300px">Chaos Dungeons</td>
             <td class="manual-row" *ngFor="let character of roster">

--- a/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.html
+++ b/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.html
@@ -36,11 +36,20 @@
                 *ngFor="let flag of row.flags; index as i; trackBy: trackByIndex">
                 <div class="cell-container">
                   <ng-container *ngIf="flag.value !== null || flag.force">
-                    <nz-switch nzCheckedChildren="Taking"
-                              nzUnCheckedChildren="Skipping"
-                              [ngModel]="!flag.value"
-                              (ngModelChange)="setChestFlag(settings.$key, display.tracking, row.gTask, roster[i], $event)"></nz-switch>
-                    (<img src="./assets/icons/gold.png" class="gold-icon" alt="gold">{{row.gTask.chestPrice}})
+                    <div class="switch-container">
+                    <nz-switch nzCheckedChildren="Taking gold"
+                              nzUnCheckedChildren="Skipping gold"
+                              [ngModel]="!flag.taking"
+                              (ngModelChange)="setGoldTakingFlag(settings.$key, display.tracking, row.gTask, roster[i], $event)"></nz-switch>
+                            </div>
+                    <div class="switch-container">
+                      <nz-switch nzCheckedChildren="Taking chest"
+                                nzUnCheckedChildren="Skipping chest"
+                                [ngModel]="!flag.value"
+                                (ngModelChange)="setChestFlag(settings.$key, display.tracking, row.gTask, roster[i], $event)"
+                                class="chest-switch"></nz-switch>
+                      ( -{{row.gTask.chestPrice}}<img src="./assets/icons/gold.png" class="gold-icon" alt="gold"> )
+                    </div>
                   </ng-container>
                   <div *ngIf="(flag.value === null || flag.force) && (flag.force !== null)">
                     <label nz-checkbox [(ngModel)]="flag.force"

--- a/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.less
+++ b/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.less
@@ -11,6 +11,7 @@
 .cell-container {
   width: 200px;
   display: flex;
+  flex-direction: column;
   flex-wrap: wrap;
 
   > div {
@@ -18,6 +19,16 @@
   }
 }
 
+.switch-container {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  margin-bottom: 5px;
+}
+
+.chest-switch {
+  margin-right: 5px;
+}
 
 .total-cell {
   font-size: 14px;

--- a/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.ts
+++ b/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.ts
@@ -42,7 +42,7 @@ export class GoldPlannerComponent {
 
   public tasks$ = this.tasksService.tasks$;
 
-  public tracking$ = this.settings.settings$.pipe(pluck("chestConfiguration"));
+  public tracking$ = this.settings.settings$.pipe(pluck("goldPlannerConfiguration"));
   public manualGoldEntries$ = this.settings.settings$.pipe(pluck("manualGoldEntries"));
   public forceAbyss$ = this.settings.settings$.pipe(pluck("forceAbyss"));
 
@@ -253,7 +253,7 @@ export class GoldPlannerComponent {
     tracking[this.getGoldChestFlag(character.name, gTask)] = !flag;
     this.settings.patch({
       $key: settingsKey,
-      chestConfiguration: tracking
+      goldPlannerConfiguration: tracking
     });
   }
 

--- a/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.ts
+++ b/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.ts
@@ -49,7 +49,7 @@ export class GoldPlannerComponent {
   private goldChestRewardPerIlvl = {
     1302: 2 * 1250,
     1415: 3 * 1250,
-	1490: 4 * 1250
+    1490: 4 * 1250
   };
 
   public display$: Observable<GoldPlannerDisplay> = combineLatest([
@@ -224,9 +224,9 @@ export class GoldPlannerComponent {
   );
 
   constructor(private rosterService: RosterService,
-              private tasksService: TasksService,
-              private settings: SettingsService,
-              private timeService: TimeService) {
+    private tasksService: TasksService,
+    private settings: SettingsService,
+    private timeService: TimeService) {
   }
 
   private getGoldChestFlag(characterName: string, gTask: GoldTask): string {
@@ -283,10 +283,9 @@ export class GoldPlannerComponent {
   }
 
   manualGoldFormatter(value: number | string): number {
-    if(!value || typeof value === 'string' ) {
+    if (!value || typeof value === 'string') {
       return 0;
     }
-    
     return Math.floor(value);
   };
 }

--- a/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.ts
+++ b/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.ts
@@ -199,7 +199,7 @@ export class GoldPlannerComponent {
         total,
         forceAbyss,
         tracking,
-        grandTotal: total.reduce((acc, v) => acc + v, chestGold),
+        grandTotal: total.reduce((acc, v) => acc + v, 0),
         chestGold,
         chaos,
         other

--- a/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.ts
+++ b/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.ts
@@ -10,7 +10,7 @@ import { Character } from "../../../model/character/character";
 import { TimeService } from "../../../core/time.service";
 import { ManualWeeklyGoldEntry, Settings } from "../../../model/settings";
 import { UpdateData } from "@angular/fire/firestore";
-
+import { getCompletionEntry } from '../../../core/get-completion-entry-key';
 
 interface GoldPlannerDisplay {
   chestsData: {
@@ -33,6 +33,7 @@ interface GoldPlannerDisplay {
   styleUrls: ["./gold-planner.component.less"]
 })
 export class GoldPlannerComponent {
+  public rawRoster$ = this.rosterService.roster$;
   public roster$ = this.rosterService.roster$.pipe(
     map(roster => roster.characters)
   );
@@ -58,9 +59,10 @@ export class GoldPlannerComponent {
     of(goldTasks),
     this.forceAbyss$,
     this.manualGoldEntries$,
-    this.timeService.lastWeeklyReset$
+    this.timeService.lastWeeklyReset$,
+    this.rawRoster$
   ]).pipe(
-    map(([roster, tasks, tracking, gTasks, forceAbyss, manualGoldEntries, weeklyReset]) => {
+    map(([roster, tasks, tracking, gTasks, forceAbyss, manualGoldEntries, weeklyReset, rawRoster]) => {
       const chestsData = gTasks
         .map(gTask => {
           if (gTask.taskName) {
@@ -81,6 +83,12 @@ export class GoldPlannerComponent {
         .map(({ gTask, task }, i, array) => {
           const flagsData = roster.map((character) => {
             if (!task || !character.weeklyGold) {
+              return {
+                force: null,
+                value: null
+              };
+            }
+            if (getCompletionEntry(rawRoster.trackedTasks, character, task, true) === false) {
               return {
                 force: null,
                 value: null


### PR DESCRIPTION
2 main features added:
- Tasks removed from a character in **Settings** are not shown for that character in **Gold Planner**
- For tasks tracked in **Gold Planner**, you have to gates from which you gain gold (this is important because you could run Kayangel for wings only, and not for gold for instance)

I also removed the **Large Chest** section as it is not predictable

Backlog:
- Choose to run NM instead of HM for specific gates
- Planning Mode VS Remaining Mode : Remaining mode will fish info from **Checklist** to hide already completed tasks and calculate how much gold you can still gain this week