### PR TITLE
Gold Planner - Opt to run NM instead of HM

### DIFF
--- a/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.html
+++ b/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.html
@@ -37,19 +37,32 @@
                 <div class="cell-container">
                   <ng-container *ngIf="flag.value !== null || flag.force">
                     <div class="switch-container">
-                    <nz-switch nzCheckedChildren="Taking gold"
-                              nzUnCheckedChildren="Skipping gold"
-                              [ngModel]="!flag.taking"
-                              (ngModelChange)="setGoldTakingFlag(settings.$key, display.tracking, row.gTask, roster[i], $event)"></nz-switch>
-                            </div>
+                      <nz-switch nzCheckedChildren="Taking gold"
+                                nzUnCheckedChildren="Skipping gold"
+                                [ngModel]="!flag.taking"
+                                (ngModelChange)="setGoldTakingFlag(settings.$key, display.tracking, row.gTask, roster[i], $event)"
+                                class="chest-switch"></nz-switch>
+                      <ng-container *ngIf="!flag.taking">
+                        ( {{flag.forceRunningNM ? row.gTask.goldReward: row.goldOverride.goldRewardNM}}<img src="./assets/icons/gold.png" class="gold-icon" alt="gold"> )
+                      </ng-container>
+                    </div>
                     <div class="switch-container">
                       <nz-switch nzCheckedChildren="Taking chest"
                                 nzUnCheckedChildren="Skipping chest"
                                 [ngModel]="!flag.value"
                                 (ngModelChange)="setChestFlag(settings.$key, display.tracking, row.gTask, roster[i], $event)"
                                 class="chest-switch"></nz-switch>
-                      ( -{{row.gTask.chestPrice}}<img src="./assets/icons/gold.png" class="gold-icon" alt="gold"> )
+                      ( -{{flag.forceRunningNM ? row.gTask.chestPrice: row.goldOverride.chestPriceNM}}<img src="./assets/icons/gold.png" class="gold-icon" alt="gold"> )
                     </div>
+                    <ng-container *ngIf="row.gTask.hasNM">
+                      <div class="switch-container">
+                        <nz-switch nzCheckedChildren="Running NM"
+                                  nzUnCheckedChildren="Running HM"
+                                  [ngModel]="!flag.forceRunningNM"
+                                  (ngModelChange)="setForceRunningNMFlag(settings.$key, display.tracking, row.gTask, roster[i], $event)"
+                        ></nz-switch>
+                      </div>
+                    </ng-container>
                   </ng-container>
                   <div *ngIf="(flag.value === null || flag.force) && (flag.force !== null)">
                     <label nz-checkbox [(ngModel)]="flag.force"

--- a/apps/client/src/app/pages/gold-planner/gold-task.ts
+++ b/apps/client/src/app/pages/gold-planner/gold-task.ts
@@ -1,6 +1,6 @@
 export interface GoldTask {
   name: string;
-  completionId?: string;
+  completionId: string;
   entryId?: string;
   taskName?: string;
   goldReward?: number;
@@ -10,4 +10,5 @@ export interface GoldTask {
   overrideMinIlvl?: number;
   overrideMaxIlvl?: number;
   canForce?: boolean;
+  hasNM?: boolean;
 }

--- a/apps/client/src/app/pages/gold-planner/gold-tasks.ts
+++ b/apps/client/src/app/pages/gold-planner/gold-tasks.ts
@@ -2,80 +2,78 @@ import { GoldTask } from "./gold-task";
 
 export const goldTasks: GoldTask[] = [
 
-  // T1 Abyss
+  // T2 Abyss Dungeon
   {
     name: "Demon Beast Canyon",
     goldReward: 80,
     taskName: "Demon Beast Canyon",
     chestPrice: 30,
-    completionId: "T1.1"
+    completionId: "T2.A1.G1"
   },
   {
     name: "Necromancer's Origin",
     goldReward: 80,
     taskName: "Necromancer's Origin",
     chestPrice: 30,
-    completionId: "T1.1"
+    completionId: "T2.A1.G2"
   },
   {
     name: "Hall of the Twisted Warlord",
     goldReward: 80,
     taskName: "Hall of the Twisted Warlord",
     chestPrice: 30,
-    completionId: "T1.2"
+    completionId: "T2.A2.G1"
   },
   {
     name: "Hildebrandt Palace",
     goldReward: 80,
     taskName: "Hildebrandt Palace",
     chestPrice: 30,
-    completionId: "T1.2"
+    completionId: "T2.A2.G2"
   },
-
-  // T2 Abyss
   {
     name: "Road of Lament",
     goldReward: 100,
     taskName: "Road of Lament",
     chestPrice: 40,
-    completionId: "T2.1"
+    completionId: "T2.A3.G1"
   },
   {
     name: "Forge of Fallen Pride",
     goldReward: 100,
     taskName: "Forge of Fallen Pride",
     chestPrice: 40,
-    completionId: "T2.1"
+    completionId: "T2.A3.G2"
   },
   {
     name: "Sea of Indolence",
     goldReward: 100,
     taskName: "Sea of Indolence",
     chestPrice: 40,
-    completionId: "T2.2"
+    completionId: "T2.A4.G1"
   },
   {
     name: "Tranquil Karkosa",
     goldReward: 100,
     taskName: "Tranquil Karkosa",
     chestPrice: 40,
-    completionId: "T2.2"
+    completionId: "T2.A4.G2"
   },
   {
     name: "Alaric's Sanctuary",
     goldReward: 100,
     taskName: "Alaric's Sanctuary",
     chestPrice: 40,
-    completionId: "T2.2"
+    completionId: "T2.A4.G3"
   },
 
-  // T3 Abyss
+  // T3 Abyss Dungeon - ilvl below Argos
   {
     name: "Aira's Oculus (Normal)",
     goldReward: 200,
     taskName: "Aira's Oculus",
     chestPrice: 100,
-    completionId: "T3.1",
+    completionId: "T3.A1.G1",
     entryId: "T3.1.0"
   },
   {
@@ -83,7 +81,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 300,
     taskName: "Oreha Preveza",
     chestPrice: 150,
-    completionId: "T3.1",
+    completionId: "T3.A1.G2",
     entryId: "T3.1.1"
   },
   {
@@ -91,27 +89,29 @@ export const goldTasks: GoldTask[] = [
     goldReward: 300,
     taskName: "Aira's Oculus",
     chestPrice: 100,
-    completionId: "T3.1",
+    completionId: "T3.A1.G1",
     entryId: "T3.1.0",
-    overrideMinIlvl: 1370
+    overrideMinIlvl: 1370,
+    hasNM: true
   },
   {
     name: "Oreha Preveza (Hard)",
     goldReward: 400,
     taskName: "Oreha Preveza",
     chestPrice: 150,
-    completionId: "T3.1",
+    completionId: "T3.A1.G2",
     entryId: "T3.1.1",
-    overrideMinIlvl: 1370
+    overrideMinIlvl: 1370,
+    hasNM: true
   },
 
-  // T3 Abyss Raid
+  // T3 Abyss Raid - Argos
   {
     name: "Argos Gate 1",
     goldReward: 300,
     taskName: "Argos",
     chestPrice: 100,
-    completionId: "T3.L1.1",
+    completionId: "T3.AR1.G1",
     overrideMaxIlvl: 1475,
     chestId: "Argos1"
   },
@@ -120,7 +120,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 300,
     taskName: "Argos",
     chestPrice: 150,
-    completionId: "T3.L1.2",
+    completionId: "T3.AR1.G2",
     chestId: "Argos2",
     overrideMaxIlvl: 1475,
   },
@@ -129,7 +129,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 400,
     taskName: "Argos",
     chestPrice: 150,
-    completionId: "T3.L1.3",
+    completionId: "T3.AR1.G3",
     chestId: "Argos3",
     overrideMaxIlvl: 1475,
   },
@@ -140,7 +140,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 500,
     taskName: "Valtan",
     chestPrice: 300,
-    completionId: "T3.L1.1",
+    completionId: "T3.L1.G1",
     chestId: "Valtan1",
     overrideMaxIlvl: 1445
   },
@@ -149,7 +149,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 700,
     taskName: "Valtan",
     chestPrice: 400,
-    completionId: "T3.L1.2",
+    completionId: "T3.L1.G2",
     chestId: "Valtan2",
     overrideMaxIlvl: 1445
   },
@@ -158,25 +158,27 @@ export const goldTasks: GoldTask[] = [
     goldReward: 700,
     taskName: "Valtan",
     chestPrice: 450,
-    completionId: "T3.L1.1",
+    completionId: "T3.L1.G1",
     chestId: "Valtan1",
-    overrideMinIlvl: 1445
+    overrideMinIlvl: 1445,
+    hasNM: true
   },
   {
     name: "Valtan Hard Gate 2",
     goldReward: 1100,
     taskName: "Valtan",
     chestPrice: 600,
-    completionId: "T3.L1.2",
+    completionId: "T3.L1.G2",
     chestId: "Valtan2",
-    overrideMinIlvl: 1445
+    overrideMinIlvl: 1445,
+    hasNM: true
   },
   {
     name: "Vykas Normal Gate 1",
     goldReward: 600,
     taskName: "Vykas",
     chestPrice: 300,
-    completionId: "T3.L2.1",
+    completionId: "T3.L2.G1",
     chestId: "Vykas1",
     overrideMaxIlvl: 1460
   },
@@ -185,7 +187,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 1000,
     taskName: "Vykas",
     chestPrice: 450,
-    completionId: "T3.L2.2",
+    completionId: "T3.L2.G2",
     chestId: "Vykas2",
     overrideMaxIlvl: 1460
   },
@@ -194,25 +196,27 @@ export const goldTasks: GoldTask[] = [
     goldReward: 900,
     taskName: "Vykas",
     chestPrice: 500,
-    completionId: "T3.L2.1",
+    completionId: "T3.L2.G1",
     chestId: "Vykas1",
-    overrideMinIlvl: 1460
+    overrideMinIlvl: 1460,
+    hasNM: true
   },
   {
     name: "Vykas Hard Gate 2",
     goldReward: 1500,
     taskName: "Vykas",
     chestPrice: 650,
-    completionId: "T3.L2.2",
+    completionId: "T3.L2.G2",
     chestId: "Vykas2",
-    overrideMinIlvl: 1460
+    overrideMinIlvl: 1460,
+    hasNM: true
   },
   {
     name: "Kakul-Saydon Gate 1",
     goldReward: 600,
     taskName: "Kakul-Saydon",
     chestPrice: 300,
-    completionId: "T3.L3.1",
+    completionId: "T3.L3.G1",
     chestId: "Kakul1",
     overrideMinIlvl: 1475
   },
@@ -221,7 +225,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 900,
     taskName: "Kakul-Saydon",
     chestPrice: 500,
-    completionId: "T3.L3.2",
+    completionId: "T3.L3.G2",
     chestId: "Kakul2",
     overrideMinIlvl: 1475
   },
@@ -230,7 +234,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 1500,
     taskName: "Kakul-Saydon",
     chestPrice: 700,
-    completionId: "T3.L3.3",
+    completionId: "T3.L3.G3",
     chestId: "Kakul3",
     overrideMinIlvl: 1475
   },
@@ -239,7 +243,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 2000,
     taskName: "Brelshaza Gate 1-2",
     chestPrice: 400,
-    completionId: "T3.L4.1",
+    completionId: "T3.L4.G1",
     chestId: "BrelshazaN1",
     overrideMinIlvl: 1490,
     overrideMaxIlvl: 1540
@@ -249,7 +253,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 2500,
     taskName: "Brelshaza Gate 1-2",
     chestPrice: 600,
-    completionId: "T3.L4.2",
+    completionId: "T3.L4.G2",
     chestId: "BrelshazaN2",
     overrideMinIlvl: 1490,
     overrideMaxIlvl: 1540
@@ -259,7 +263,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 1500,
     taskName: "Brelshaza Gate 3",
     chestPrice: 800,
-    completionId: "T3.L4.3",
+    completionId: "T3.L4.G3",
     chestId: "BrelshazaN3",
     overrideMinIlvl: 1500,
     overrideMaxIlvl: 1550
@@ -269,7 +273,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 2500,
     taskName: "Brelshaza Gate 4",
     chestPrice: 1500,
-    completionId: "T3.L4.4",
+    completionId: "T3.L4.G4",
     chestId: "BrelshazaN4",
     overrideMinIlvl: 1520,
     overrideMaxIlvl: 1560
@@ -279,43 +283,49 @@ export const goldTasks: GoldTask[] = [
     goldReward: 2500,
     taskName: "Brelshaza Gate 1-2",
     chestPrice: 700,
-    completionId: "T3.L5.1",
+    completionId: "T3.L4.G1",
     chestId: "BrelshazaH1",
-    overrideMinIlvl: 1540
+    overrideMinIlvl: 1540,
+    hasNM: true
     },
   {
     name: "Brelshaza Hard Gate 2",
     goldReward: 3000,
     taskName: "Brelshaza Gate 1-2",
     chestPrice: 900,
-    completionId: "T3.L5.2",
+    completionId: "T3.L4.G2",
     chestId: "BrelshazaH2",
-    overrideMinIlvl: 1540
+    overrideMinIlvl: 1540,
+    hasNM: true
   },
   {
     name: "Brelshaza Hard Gate 3",
     goldReward: 2000,
     taskName: "Brelshaza Gate 3",
     chestPrice: 1100,
-    completionId: "T3.L5.3",
+    completionId: "T3.L4.G3",
     chestId: "BrelshazaH3",
-    overrideMinIlvl: 1550
+    overrideMinIlvl: 1550,
+    hasNM: true
   },
   {
     name: "Brelshaza Hard Gate 4",
     goldReward: 3000,
     taskName: "Brelshaza Gate 4",
     chestPrice: 1800,
-    completionId: "T3.L5.4",
+    completionId: "T3.L4.G4",
     chestId: "BrelshazaH4",
-    overrideMinIlvl: 1560
+    overrideMinIlvl: 1560,
+    hasNM: true
   },
+
+  // Abyss Raid - Kayangel
   {
     name: "Kayangel Normal Gate 1",
     goldReward: 1000,
     taskName: "Kayangel",
     chestPrice: 600,
-    completionId: "T3.L6.1",
+    completionId: "T3.AR2.G1",
     chestId: "KayangelN1",
     overrideMinIlvl: 1540,
     overrideMaxIlvl: 1580
@@ -325,7 +335,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 1500,
     taskName: "Kayangel",
     chestPrice: 800,
-    completionId: "T3.L6.2",
+    completionId: "T3.AR2.G2",
     chestId: "KayangelN2",
     overrideMinIlvl: 1540,
     overrideMaxIlvl: 1580
@@ -335,7 +345,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 2000,
     taskName: "Kayangel",
     chestPrice: 1000,
-    completionId: "T3.L6.3",
+    completionId: "T3.AR2.G3",
     chestId: "KayangelN3",
     overrideMinIlvl: 1540,
     overrideMaxIlvl: 1580
@@ -345,34 +355,39 @@ export const goldTasks: GoldTask[] = [
     goldReward: 1500,
     taskName: "Kayangel",
     chestPrice: 700,
-    completionId: "T3.L7.1",
+    completionId: "T3.AR2.G1",
     chestId: "KayangelH1",
-    overrideMinIlvl: 1580
+    overrideMinIlvl: 1580,
+    hasNM: true
   },
   {
     name: "Kayangel Hard Gate 2",
     goldReward: 2000,
     taskName: "Kayangel",
     chestPrice: 900,
-    completionId: "T3.L7.2",
+    completionId: "T3.AR2.G2",
     chestId: "KayangelH2",
-    overrideMinIlvl: 1580
+    overrideMinIlvl: 1580,
+    hasNM: true
   },
   {
     name: "Kayangel Hard Gate 3",
     goldReward: 3000,
     taskName: "Kayangel",
     chestPrice: 1100,
-    completionId: "T3.L7.3",
+    completionId: "T3.AR2.G3",
     chestId: "KayangelH3",
-    overrideMinIlvl: 1580
+    overrideMinIlvl: 1580,
+    hasNM: true
   },
+
+  // Legion Raid - Akkan
   {
     name: "Akkan Normal Gate 1",
     goldReward: 1500,
     taskName: "Akkan",
     chestPrice: 900,
-    completionId: "T3.L8.1",
+    completionId: "T3.L5.G1",
     chestId: "AkkanN1",
     overrideMinIlvl: 1580,
     overrideMaxIlvl: 1600
@@ -382,7 +397,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 2000,
     taskName: "Akkan",
     chestPrice: 1100,
-    completionId: "T3.L8.2",
+    completionId: "T3.L5.G2",
     chestId: "AkkanN2",
     overrideMinIlvl: 1580,
     overrideMaxIlvl: 1600
@@ -392,7 +407,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 4000,
     taskName: "Akkan",
     chestPrice: 1500,
-    completionId: "T3.L8.3",
+    completionId: "T3.L5.G3",
     chestId: "AkkanN3",
     overrideMinIlvl: 1580,
     overrideMaxIlvl: 1600
@@ -402,34 +417,39 @@ export const goldTasks: GoldTask[] = [
   goldReward: 1750,
   taskName: "Akkan",
   chestPrice: 1200,
-  completionId: "T3.L9.1",
+  completionId: "T3.L5.G1",
   chestId: "AkkanH1",
-  overrideMinIlvl: 1600
+  overrideMinIlvl: 1600,
+  hasNM: true
 },
 {
   name: "Akkan Hard Gate 2",
   goldReward: 2500,
   taskName: "Akkan",
   chestPrice: 1400,
-  completionId: "T3.L9.2",
+  completionId: "T3.L5.G2",
   chestId: "AkkanH2",
-  overrideMinIlvl: 1600
+  overrideMinIlvl: 1600,
+  hasNM: true
 },
 {
   name: "Akkan Hard Gate 3",
   goldReward: 5750,
   taskName: "Akkan",
   chestPrice: 1900,
-  completionId: "T3.L9.3",
+  completionId: "T3.L5.G3",
   chestId: "AkkanH3",
-  overrideMinIlvl: 1600
+  overrideMinIlvl: 1600,
+  hasNM: true
 },
+
+// Abyss Raid - Ivory Tower - Voldis
 {
   name: "Ivory Tower Normal Gate 1",
   goldReward: 1500,
   taskName: "Ivory Tower",
   chestPrice: 700,
-  completionId: "T3.L10.1",
+  completionId: "T3.AR3.G1",
   chestId: "IvoryTowerN1",
   overrideMinIlvl: 1600,
   overrideMaxIlvl: 1620
@@ -439,7 +459,7 @@ export const goldTasks: GoldTask[] = [
   goldReward: 1750,
   taskName: "Ivory Tower",
   chestPrice: 800,
-  completionId: "T3.L10.2",
+  completionId: "T3.AR3.G2",
   chestId: "IvoryTowerN2",
   overrideMinIlvl: 1600,
   overrideMaxIlvl: 1620
@@ -449,7 +469,7 @@ export const goldTasks: GoldTask[] = [
   goldReward: 2500,
   taskName: "Ivory Tower",
   chestPrice: 900,
-  completionId: "T3.L10.3",
+  completionId: "T3.AR3.G3",
   chestId: "IvoryTowerN3",
   overrideMinIlvl: 1600,
   overrideMaxIlvl: 1620
@@ -459,7 +479,7 @@ export const goldTasks: GoldTask[] = [
   goldReward: 3250,
   taskName: "Ivory Tower",
   chestPrice: 1100,
-  completionId: "T3.L10.4",
+  completionId: "T3.AR3.G4",
   chestId: "IvoryTowerN4",
   overrideMinIlvl: 1600,
   overrideMaxIlvl: 1620
@@ -469,43 +489,49 @@ export const goldTasks: GoldTask[] = [
   goldReward: 2000,
   taskName: "Ivory Tower",
   chestPrice: 1000,
-  completionId: "T3.L11.1",
+  completionId: "T3.AR3.G1",
   chestId: "IvoryTowerH1",
-  overrideMinIlvl: 1620
+  overrideMinIlvl: 1620,
+  hasNM: true
 },
 {
   name: "Ivory Tower Hard Gate 2",
   goldReward: 2500,
   taskName: "Ivory Tower",
   chestPrice: 1000,
-  completionId: "T3.L11.2",
+  completionId: "T3.AR3.G2",
   chestId: "IvoryTowerH2",
-  overrideMinIlvl: 1620
+  overrideMinIlvl: 1620,
+  hasNM: true
 },
 {
   name: "Ivory Tower Hard Gate 3",
   goldReward: 4000,
   taskName: "Ivory Tower",
   chestPrice: 1500,
-  completionId: "T3.L11.3",
+  completionId: "T3.AR3.G3",
   chestId: "IvoryTowerH3",
-  overrideMinIlvl: 1620
+  overrideMinIlvl: 1620,
+  hasNM: true
 },
 {
   name: "Ivory Tower Hard Gate 4",
   goldReward: 6000,
   taskName: "Ivory Tower",
   chestPrice: 2000,
-  completionId: "T3.L11.4",
+  completionId: "T3.AR3.G4",
   chestId: "IvoryTowerH4",
-  overrideMinIlvl: 1620
+  overrideMinIlvl: 1620,
+  hasNM: true
 },
+
+// Legion Raid - Thaemine
 {
   name: "Thaemine Normal Gate 1",
   goldReward: 3500,
   taskName: "Thaemine",
   chestPrice: 1500,
-  completionId: "T3.L12.1",
+  completionId: "T3.L6.G1",
   chestId: "ThaemineN1",
   overrideMinIlvl: 1610,
   overrideMaxIlvl: 1630
@@ -515,7 +541,7 @@ export const goldTasks: GoldTask[] = [
   goldReward: 4000,
   taskName: "Thaemine",
   chestPrice: 1800,
-  completionId: "T3.L12.2",
+  completionId: "T3.L6.G2",
   chestId: "ThaemineN2",
   overrideMinIlvl: 1610,
   overrideMaxIlvl: 1630
@@ -525,7 +551,7 @@ export const goldTasks: GoldTask[] = [
   goldReward: 5500,
   taskName: "Thaemine",
   chestPrice: 2500,
-  completionId: "T3.L12.3",
+  completionId: "T3.L6.G3",
   chestId: "ThaemineN3",
   overrideMinIlvl: 1610,
   overrideMaxIlvl: 1630
@@ -535,43 +561,48 @@ export const goldTasks: GoldTask[] = [
   goldReward: 5000,
   taskName: "Thaemine",
   chestPrice: 2000,
-  completionId: "T3.L13.1",
+  completionId: "T3.L6.G1",
   chestId: "ThaemineH1",
-  overrideMinIlvl: 1630
+  overrideMinIlvl: 1630,
+  hasNM: true
 },
 {
   name: "Thaemine Hard Gate 2",
   goldReward: 6000,
   taskName: "Thaemine",
   chestPrice: 2400,
-  completionId: "T3.L13.2",
+  completionId: "T3.L6.G2",
   chestId: "ThaemineH2",
-  overrideMinIlvl: 1630
+  overrideMinIlvl: 1630,
+  hasNM: true
 },
 {
   name: "Thaemine Hard Gate 3",
   goldReward: 9000,
   taskName: "Thaemine",
   chestPrice: 2800,
-  completionId: "T3.L13.3",
+  completionId: "T3.L6.G3",
   chestId: "ThaemineH3",
-  overrideMinIlvl: 1630
+  overrideMinIlvl: 1630,
+  hasNM: true
 },
 {
   name: "Thaemine Hard Gate 4",
   goldReward: 21000,
   taskName: "Thaemine G4",
   chestPrice: 3600,
-  completionId: "T3.L13.4",
+  completionId: "T3.L6.G4",
   chestId: "ThaemineH4",
   overrideMinIlvl: 1630
 },
+
+// Kazeros Raid
 {
   name: "Echidna Normal Gate 1",
   goldReward: 5000,
   taskName: "Echidna",
   chestPrice: 2200,
-  completionId: "T3.L14.1",
+  completionId: "T3.K1.G1",
   chestId: "EchidnaN1",
   overrideMinIlvl: 1620,
   overrideMaxIlvl: 1630
@@ -581,7 +612,7 @@ export const goldTasks: GoldTask[] = [
   goldReward: 9500,
   taskName: "Echidna",
   chestPrice: 3400,
-  completionId: "T3.L14.2",
+  completionId: "T3.K1.G2",
   chestId: "EchidnaN2",
   overrideMinIlvl: 1620,
   overrideMaxIlvl: 1630
@@ -591,17 +622,19 @@ export const goldTasks: GoldTask[] = [
   goldReward: 6000,
   taskName: "Echidna",
   chestPrice: 2800,
-  completionId: "T3.L15.1",
+  completionId: "T3.K1.G1",
   chestId: "EchidnaH1",
-  overrideMinIlvl: 1630
+  overrideMinIlvl: 1630,
+  hasNM: true
 },
 {
   name: "Echidna Hard Gate 2",
   goldReward: 12500,
   taskName: "Echidna",
   chestPrice: 4100,
-  completionId: "T3.L15.2",
+  completionId: "T3.K1.G2",
   chestId: "EchidnaH2",
-  overrideMinIlvl: 1630
+  overrideMinIlvl: 1630,
+  hasNM: true
 }
 ];


### PR DESCRIPTION
You can now chose to run a raid in Normal Mode even if you could enter Hard Mode.
The Gold Planner will use NM gold/chest values in the planning
![image](https://github.com/user-attachments/assets/aff5d8f5-bb78-4115-aaaf-c7e90935c00f)
