### PR TITLE
Gold planner rework

### DIFF
--- a/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.html
+++ b/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.html
@@ -37,19 +37,32 @@
                 <div class="cell-container">
                   <ng-container *ngIf="flag.value !== null || flag.force">
                     <div class="switch-container">
-                    <nz-switch nzCheckedChildren="Taking gold"
-                              nzUnCheckedChildren="Skipping gold"
-                              [ngModel]="!flag.taking"
-                              (ngModelChange)="setGoldTakingFlag(settings.$key, display.tracking, row.gTask, roster[i], $event)"></nz-switch>
-                            </div>
+                      <nz-switch nzCheckedChildren="Taking gold"
+                                nzUnCheckedChildren="Skipping gold"
+                                [ngModel]="!flag.taking"
+                                (ngModelChange)="setGoldTakingFlag(settings.$key, display.tracking, row.gTask, roster[i], $event)"
+                                class="chest-switch"></nz-switch>
+                      <ng-container *ngIf="!flag.taking">
+                        ( {{flag.forceRunningNM ? row.gTask.goldReward: row.goldOverride.goldRewardNM}}<img src="./assets/icons/gold.png" class="gold-icon" alt="gold"> )
+                      </ng-container>
+                    </div>
                     <div class="switch-container">
                       <nz-switch nzCheckedChildren="Taking chest"
                                 nzUnCheckedChildren="Skipping chest"
                                 [ngModel]="!flag.value"
                                 (ngModelChange)="setChestFlag(settings.$key, display.tracking, row.gTask, roster[i], $event)"
                                 class="chest-switch"></nz-switch>
-                      ( -{{row.gTask.chestPrice}}<img src="./assets/icons/gold.png" class="gold-icon" alt="gold"> )
+                      ( -{{flag.forceRunningNM ? row.gTask.chestPrice: row.goldOverride.chestPriceNM}}<img src="./assets/icons/gold.png" class="gold-icon" alt="gold"> )
                     </div>
+                    <ng-container *ngIf="row.gTask.hasNM">
+                      <div class="switch-container">
+                        <nz-switch nzCheckedChildren="Running NM"
+                                  nzUnCheckedChildren="Running HM"
+                                  [ngModel]="!flag.forceRunningNM"
+                                  (ngModelChange)="setForceRunningNMFlag(settings.$key, display.tracking, row.gTask, roster[i], $event)"
+                        ></nz-switch>
+                      </div>
+                    </ng-container>
                   </ng-container>
                   <div *ngIf="(flag.value === null || flag.force) && (flag.force !== null)">
                     <label nz-checkbox [(ngModel)]="flag.force"

--- a/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.html
+++ b/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.html
@@ -29,37 +29,36 @@
             <tr>
               <td nzLeft nzWidth="280px" class="task-name">
                 <img *ngIf="row.task?.iconPath" src="./assets/icons/{{row.task?.iconPath}}" alt="" class="task-icon">
-                {{row.gTask.name}} - 
-                (<img src="./assets/icons/gold.png" class="gold-icon" alt="gold">{{row.gTask.goldReward}})
+                {{row.gTask.name}}
               </td>
               <td 
-                *ngFor="let flag of row.flags; index as i; trackBy: trackByIndex">
+                *ngFor="let flag of row.goldDetails; index as i; trackBy: trackByIndex">
                 <div class="cell-container">
-                  <ng-container *ngIf="flag.value !== null || flag.force">
+                  <ng-container *ngIf="!flag.hide">
                     <div class="switch-container">
                       <nz-switch nzCheckedChildren="Taking gold"
                                 nzUnCheckedChildren="Skipping gold"
-                                [ngModel]="!flag.taking"
+                                [ngModel]="!flag.takingGold"
                                 (ngModelChange)="setGoldTakingFlag(settings.$key, display.tracking, row.gTask, roster[i], $event)"
                                 class="chest-switch"></nz-switch>
-                      <ng-container *ngIf="!flag.taking">
-                        ( {{flag.forceRunningNM ? row.gTask.goldReward: row.goldOverride.goldRewardNM}}<img src="./assets/icons/gold.png" class="gold-icon" alt="gold"> )
+                      <ng-container *ngIf="!flag.takingGold">
+                        ( {{flag.goldReward}}<img src="./assets/icons/gold.png" class="gold-icon" alt="gold"> )
                       </ng-container>
                     </div>
                     <div class="switch-container">
                       <nz-switch nzCheckedChildren="Taking chest"
                                 nzUnCheckedChildren="Skipping chest"
-                                [ngModel]="!flag.value"
+                                [ngModel]="!flag.takingChest"
                                 (ngModelChange)="setChestFlag(settings.$key, display.tracking, row.gTask, roster[i], $event)"
                                 class="chest-switch"></nz-switch>
-                      ( -{{flag.forceRunningNM ? row.gTask.chestPrice: row.goldOverride.chestPriceNM}}<img src="./assets/icons/gold.png" class="gold-icon" alt="gold"> )
+                      ( -{{flag.chestPrice}}<img src="./assets/icons/gold.png" class="gold-icon" alt="gold"> )
                     </div>
-                    <ng-container *ngIf="row.gTask.hasNM">
+                    <ng-container *ngIf="flag.canRunHM">
                       <div class="switch-container">
-                        <nz-switch nzCheckedChildren="Running NM"
-                                  nzUnCheckedChildren="Running HM"
-                                  [ngModel]="!flag.forceRunningNM"
-                                  (ngModelChange)="setForceRunningNMFlag(settings.$key, display.tracking, row.gTask, roster[i], $event)"
+                        <nz-switch nzCheckedChildren="Running HM"
+                                  nzUnCheckedChildren="Running NM"
+                                  [ngModel]="!flag.runningHM"
+                                  (ngModelChange)="setRunningHMFlag(settings.$key, display.tracking, row.gTask, roster[i], $event)"
                         ></nz-switch>
                       </div>
                     </ng-container>

--- a/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.html
+++ b/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.html
@@ -63,21 +63,10 @@
                       </div>
                     </ng-container>
                   </ng-container>
-                  <div *ngIf="(flag.value === null || flag.force) && (flag.force !== null)">
-                    <label nz-checkbox [(ngModel)]="flag.force"
-                          (ngModelChange)="setForceAbyss(settings.$key, display.forceAbyss, row.gTask, roster[i], $event)"></label>
-                    Force
-                  </div>
                 </div>
               </td>
             </tr>
           </ng-container>
-          <!-- <tr>
-            <td nzLeft nzWidth="300px">Large Gold Chest(s) - (<img src="./assets/icons/gold.png"
-              class="gold-icon" alt="gold">{{display.chestGold | number}})</td>
-            <td [attr.colspan]="display.total.length" class="roster-income">
-            </td>
-          </tr> -->
           <tr>
             <td nzLeft nzWidth="300px">Chaos Dungeons</td>
             <td class="manual-row" *ngFor="let character of roster">

--- a/apps/client/src/app/pages/gold-planner/gold-task.ts
+++ b/apps/client/src/app/pages/gold-planner/gold-task.ts
@@ -1,6 +1,6 @@
 export interface GoldTask {
   name: string;
-  completionId?: string;
+  completionId: string;
   entryId?: string;
   taskName?: string;
   goldReward?: number;
@@ -10,4 +10,5 @@ export interface GoldTask {
   overrideMinIlvl?: number;
   overrideMaxIlvl?: number;
   canForce?: boolean;
+  hasNM?: boolean;
 }

--- a/apps/client/src/app/pages/gold-planner/gold-task.ts
+++ b/apps/client/src/app/pages/gold-planner/gold-task.ts
@@ -7,8 +7,10 @@ export interface GoldTask {
   goldRewardPerIlvl?: Record<number, number>;
   chestPrice?: number;
   chestId?: string;
-  overrideMinIlvl?: number;
-  overrideMaxIlvl?: number;
-  canForce?: boolean;
-  hasNM?: boolean;
+  modes?: {
+      name: string,
+      goldReward: number,
+      chestPrice: number,
+      HMThreashold: number
+    }[]
 }

--- a/apps/client/src/app/pages/gold-planner/gold-task.ts
+++ b/apps/client/src/app/pages/gold-planner/gold-task.ts
@@ -1,11 +1,7 @@
 export interface GoldTask {
   name: string;
   completionId: string;
-  entryId?: string;
   taskName?: string;
-  goldReward?: number;
-  goldRewardPerIlvl?: Record<number, number>;
-  chestPrice?: number;
   chestId?: string;
   modes?: {
       name: string,

--- a/apps/client/src/app/pages/gold-planner/gold-tasks.ts
+++ b/apps/client/src/app/pages/gold-planner/gold-tasks.ts
@@ -5,636 +5,731 @@ export const goldTasks: GoldTask[] = [
   // T2 Abyss Dungeon
   {
     name: "Demon Beast Canyon",
-    goldReward: 80,
     taskName: "Demon Beast Canyon",
-    chestPrice: 30,
-    completionId: "T2.A1.G1"
+    completionId: "T2.A1.G1",
+    modes: [
+      {
+        name: "NM",
+        goldReward: 80,
+        chestPrice: 0,
+        HMThreashold: Infinity
+      }
+    ]
   },
   {
     name: "Necromancer's Origin",
-    goldReward: 80,
     taskName: "Necromancer's Origin",
-    chestPrice: 30,
-    completionId: "T2.A1.G2"
+    completionId: "T2.A1.G2",
+    modes: [
+      {
+        name: "NM",
+        goldReward: 80,
+        chestPrice: 0,
+        HMThreashold: Infinity
+      }
+    ]
   },
   {
     name: "Hall of the Twisted Warlord",
-    goldReward: 80,
     taskName: "Hall of the Twisted Warlord",
-    chestPrice: 30,
-    completionId: "T2.A2.G1"
+    completionId: "T2.A2.G1",
+    modes: [
+      {
+        name: "NM",
+        goldReward: 80,
+        chestPrice: 0,
+        HMThreashold: Infinity
+      }
+    ]
   },
   {
     name: "Hildebrandt Palace",
-    goldReward: 80,
     taskName: "Hildebrandt Palace",
-    chestPrice: 30,
-    completionId: "T2.A2.G2"
+    completionId: "T2.A2.G2",
+    modes: [
+      {
+        name: "NM",
+        goldReward: 80,
+        chestPrice: 0,
+        HMThreashold: Infinity
+      }
+    ]
   },
   {
     name: "Road of Lament",
-    goldReward: 100,
     taskName: "Road of Lament",
-    chestPrice: 40,
-    completionId: "T2.A3.G1"
+    completionId: "T2.A3.G1",
+    modes: [
+      {
+        name: "NM",
+        goldReward: 100,
+        chestPrice: 0,
+        HMThreashold: Infinity
+      }
+    ]
   },
   {
     name: "Forge of Fallen Pride",
-    goldReward: 100,
     taskName: "Forge of Fallen Pride",
-    chestPrice: 40,
-    completionId: "T2.A3.G2"
+    completionId: "T2.A3.G2",
+    modes: [
+      {
+        name: "NM",
+        goldReward: 100,
+        chestPrice: 0,
+        HMThreashold: Infinity
+      }
+    ]
   },
   {
     name: "Sea of Indolence",
-    goldReward: 100,
     taskName: "Sea of Indolence",
-    chestPrice: 40,
-    completionId: "T2.A4.G1"
+    completionId: "T2.A4.G1",
+    modes: [
+      {
+        name: "NM",
+        goldReward: 100,
+        chestPrice: 0,
+        HMThreashold: Infinity
+      }
+    ]
   },
   {
     name: "Tranquil Karkosa",
-    goldReward: 100,
     taskName: "Tranquil Karkosa",
-    chestPrice: 40,
-    completionId: "T2.A4.G2"
+    completionId: "T2.A4.G2",
+    modes: [
+      {
+        name: "NM",
+        goldReward: 100,
+        chestPrice: 0,
+        HMThreashold: Infinity
+      }
+    ]
   },
   {
     name: "Alaric's Sanctuary",
-    goldReward: 100,
     taskName: "Alaric's Sanctuary",
-    chestPrice: 40,
-    completionId: "T2.A4.G3"
+    completionId: "T2.A4.G3",
+    modes: [
+      {
+        name: "NM",
+        goldReward: 100,
+        chestPrice: 0,
+        HMThreashold: Infinity
+      }
+    ]
   },
 
   // T3 Abyss Dungeon - ilvl below Argos
   {
-    name: "Aira's Oculus (Normal)",
-    goldReward: 200,
+    name: "Aira's Oculus",
     taskName: "Aira's Oculus",
-    chestPrice: 100,
     completionId: "T3.A1.G1",
-    entryId: "T3.1.0"
+    modes: [
+      {
+        name: "NM",
+        goldReward: 200,
+        chestPrice: 100,
+        HMThreashold: 1370
+      },
+      {
+        name: "HM",
+        goldReward: 300,
+        chestPrice: 100,
+        HMThreashold: Infinity
+      }
+    ]
   },
   {
-    name: "Oreha Preveza (Normal)",
-    goldReward: 300,
+    name: "Oreha Preveza",
     taskName: "Oreha Preveza",
-    chestPrice: 150,
     completionId: "T3.A1.G2",
-    entryId: "T3.1.1"
-  },
-  {
-    name: "Aira's Oculus (Hard)",
-    goldReward: 300,
-    taskName: "Aira's Oculus",
-    chestPrice: 100,
-    completionId: "T3.A1.G1",
-    entryId: "T3.1.0",
-    overrideMinIlvl: 1370,
-    hasNM: true
-  },
-  {
-    name: "Oreha Preveza (Hard)",
-    goldReward: 400,
-    taskName: "Oreha Preveza",
-    chestPrice: 150,
-    completionId: "T3.A1.G2",
-    entryId: "T3.1.1",
-    overrideMinIlvl: 1370,
-    hasNM: true
+    modes: [
+      {
+        name: "NM",
+        goldReward: 300,
+        chestPrice: 150,
+        HMThreashold: 1370
+      },
+      {
+        name: "HM",
+        goldReward: 400,
+        chestPrice: 150,
+        HMThreashold: Infinity
+      }
+    ]
   },
 
   // T3 Abyss Raid - Argos
   {
     name: "Argos Gate 1",
-    goldReward: 300,
     taskName: "Argos",
-    chestPrice: 100,
     completionId: "T3.AR1.G1",
-    overrideMaxIlvl: 1475,
-    chestId: "Argos1"
+    chestId: "Argos1",
+    modes: [
+      {
+        name: "NM",
+        goldReward: 300,
+        chestPrice: 100,
+        HMThreashold: Infinity
+      }
+    ]
   },
   {
     name: "Argos Gate 2",
-    goldReward: 300,
     taskName: "Argos",
-    chestPrice: 150,
     completionId: "T3.AR1.G2",
     chestId: "Argos2",
-    overrideMaxIlvl: 1475,
+    modes: [
+      {
+        name: "NM",
+        goldReward: 300,
+        chestPrice: 150,
+        HMThreashold: Infinity
+      }
+    ]
   },
   {
     name: "Argos Gate 3",
-    goldReward: 400,
     taskName: "Argos",
-    chestPrice: 150,
     completionId: "T3.AR1.G3",
     chestId: "Argos3",
-    overrideMaxIlvl: 1475,
+    modes: [
+      {
+        name: "NM",
+        goldReward: 400,
+        chestPrice: 150,
+        HMThreashold: Infinity
+      }
+    ]
   },
 
   // T3 Legion Raid
   {
-    name: "Valtan Normal Gate 1",
-    goldReward: 500,
+    name: "Valtan Gate 1",
     taskName: "Valtan",
-    chestPrice: 300,
-    completionId: "T3.L1.G1",
+    completionId: "T3.L12.G1",
     chestId: "Valtan1",
-    overrideMaxIlvl: 1445
+    modes: [
+      {
+        name: "NM",
+        goldReward: 500,
+        chestPrice: 300,
+        HMThreashold: 1445
+      },
+      {
+        name: "HM",
+        goldReward: 700,
+        chestPrice: 450,
+        HMThreashold: Infinity
+      }
+    ]
   },
   {
-    name: "Valtan Normal Gate 2",
-    goldReward: 700,
+    name: "Valtan Gate 2",
     taskName: "Valtan",
-    chestPrice: 400,
     completionId: "T3.L1.G2",
     chestId: "Valtan2",
-    overrideMaxIlvl: 1445
+    modes: [
+      {
+        name: "NM",
+        goldReward: 700,
+        chestPrice: 400,
+        HMThreashold: 1445
+      },
+      {
+        name: "HM",
+        goldReward: 1100,
+        chestPrice: 600,
+        HMThreashold: Infinity
+      }
+    ]
   },
   {
-    name: "Valtan Hard Gate 1",
-    goldReward: 700,
-    taskName: "Valtan",
-    chestPrice: 450,
-    completionId: "T3.L1.G1",
-    chestId: "Valtan1",
-    overrideMinIlvl: 1445,
-    hasNM: true
-  },
-  {
-    name: "Valtan Hard Gate 2",
-    goldReward: 1100,
-    taskName: "Valtan",
-    chestPrice: 600,
-    completionId: "T3.L1.G2",
-    chestId: "Valtan2",
-    overrideMinIlvl: 1445,
-    hasNM: true
-  },
-  {
-    name: "Vykas Normal Gate 1",
-    goldReward: 600,
+    name: "Vykas Gate 1",
     taskName: "Vykas",
-    chestPrice: 300,
     completionId: "T3.L2.G1",
     chestId: "Vykas1",
-    overrideMaxIlvl: 1460
+    modes: [
+      {
+        name: "NM",
+        goldReward: 600,
+        chestPrice: 300,
+        HMThreashold: 1460
+      },
+      {
+        name: "HM",
+        goldReward: 900,
+        chestPrice: 500,
+        HMThreashold: Infinity
+      }
+    ]
   },
   {
-    name: "Vykas Normal Gate 2",
-    goldReward: 1000,
+    name: "Vykas Gate 2",
     taskName: "Vykas",
-    chestPrice: 450,
     completionId: "T3.L2.G2",
     chestId: "Vykas2",
-    overrideMaxIlvl: 1460
-  },
-  {
-    name: "Vykas Hard Gate 1",
-    goldReward: 900,
-    taskName: "Vykas",
-    chestPrice: 500,
-    completionId: "T3.L2.G1",
-    chestId: "Vykas1",
-    overrideMinIlvl: 1460,
-    hasNM: true
-  },
-  {
-    name: "Vykas Hard Gate 2",
-    goldReward: 1500,
-    taskName: "Vykas",
-    chestPrice: 650,
-    completionId: "T3.L2.G2",
-    chestId: "Vykas2",
-    overrideMinIlvl: 1460,
-    hasNM: true
+    modes: [
+      {
+        name: "NM",
+        goldReward: 1000,
+        chestPrice: 450,
+        HMThreashold: 1460
+      },
+      {
+        name: "HM",
+        goldReward: 1500,
+        chestPrice: 650,
+        HMThreashold: Infinity
+      }
+    ]
   },
   {
     name: "Kakul-Saydon Gate 1",
-    goldReward: 600,
     taskName: "Kakul-Saydon",
-    chestPrice: 300,
     completionId: "T3.L3.G1",
     chestId: "Kakul1",
-    overrideMinIlvl: 1475
+    modes: [
+      {
+        name: "NM",
+        goldReward: 600,
+        chestPrice: 300,
+        HMThreashold: Infinity
+      }
+    ]
   },
   {
     name: "Kakul-Saydon Gate 2",
-    goldReward: 900,
     taskName: "Kakul-Saydon",
-    chestPrice: 500,
     completionId: "T3.L3.G2",
     chestId: "Kakul2",
-    overrideMinIlvl: 1475
+    modes: [
+      {
+        name: "NM",
+        goldReward: 900,
+        chestPrice: 500,
+        HMThreashold: Infinity
+      }
+    ]
   },
   {
     name: "Kakul-Saydon Gate 3",
-    goldReward: 1500,
     taskName: "Kakul-Saydon",
-    chestPrice: 700,
     completionId: "T3.L3.G3",
     chestId: "Kakul3",
-    overrideMinIlvl: 1475
+    modes: [
+      {
+        name: "NM",
+        goldReward: 1500,
+        chestPrice: 700,
+        HMThreashold: Infinity
+      }
+    ]
   },
   {
-    name: "Brelshaza Normal Gate 1",
-    goldReward: 2000,
+    name: "Brelshaza Gate 1",
     taskName: "Brelshaza Gate 1-2",
-    chestPrice: 400,
     completionId: "T3.L4.G1",
     chestId: "BrelshazaN1",
-    overrideMinIlvl: 1490,
-    overrideMaxIlvl: 1540
+    modes: [
+      {
+        name: "NM",
+        goldReward: 2000,
+        chestPrice: 400,
+        HMThreashold: 1540
+      },
+      {
+        name: "HM",
+        goldReward: 2500,
+        chestPrice: 700,
+        HMThreashold: Infinity
+      }
+    ]
   },
   {
-    name: "Brelshaza Normal Gate 2",
-    goldReward: 2500,
+    name: "Brelshaza Gate 2",
     taskName: "Brelshaza Gate 1-2",
-    chestPrice: 600,
     completionId: "T3.L4.G2",
     chestId: "BrelshazaN2",
-    overrideMinIlvl: 1490,
-    overrideMaxIlvl: 1540
+    modes: [
+      {
+        name: "NM",
+        goldReward: 2500,
+        chestPrice: 600,
+        HMThreashold: 1540
+      },
+      {
+        name: "HM",
+        goldReward: 3000,
+        chestPrice: 900,
+        HMThreashold: Infinity
+      }
+    ]
   },
   {
-    name: "Brelshaza Normal Gate 3",
-    goldReward: 1500,
+    name: "Brelshaza Gate 3",
     taskName: "Brelshaza Gate 3",
-    chestPrice: 800,
     completionId: "T3.L4.G3",
     chestId: "BrelshazaN3",
-    overrideMinIlvl: 1500,
-    overrideMaxIlvl: 1550
+    modes: [
+      {
+        name: "NM",
+        goldReward: 1500,
+        chestPrice: 800,
+        HMThreashold: 1550
+      },
+      {
+        name: "HM",
+        goldReward: 2000,
+        chestPrice: 1100,
+        HMThreashold: Infinity
+      }
+    ]
   },
   {
-    name: "Brelshaza Normal Gate 4",
-    goldReward: 2500,
+    name: "Brelshaza Gate 4",
     taskName: "Brelshaza Gate 4",
-    chestPrice: 1500,
     completionId: "T3.L4.G4",
     chestId: "BrelshazaN4",
-    overrideMinIlvl: 1520,
-    overrideMaxIlvl: 1560
-  },
-  {
-    name: "Brelshaza Hard Gate 1",
-    goldReward: 2500,
-    taskName: "Brelshaza Gate 1-2",
-    chestPrice: 700,
-    completionId: "T3.L4.G1",
-    chestId: "BrelshazaH1",
-    overrideMinIlvl: 1540,
-    hasNM: true
-    },
-  {
-    name: "Brelshaza Hard Gate 2",
-    goldReward: 3000,
-    taskName: "Brelshaza Gate 1-2",
-    chestPrice: 900,
-    completionId: "T3.L4.G2",
-    chestId: "BrelshazaH2",
-    overrideMinIlvl: 1540,
-    hasNM: true
-  },
-  {
-    name: "Brelshaza Hard Gate 3",
-    goldReward: 2000,
-    taskName: "Brelshaza Gate 3",
-    chestPrice: 1100,
-    completionId: "T3.L4.G3",
-    chestId: "BrelshazaH3",
-    overrideMinIlvl: 1550,
-    hasNM: true
-  },
-  {
-    name: "Brelshaza Hard Gate 4",
-    goldReward: 3000,
-    taskName: "Brelshaza Gate 4",
-    chestPrice: 1800,
-    completionId: "T3.L4.G4",
-    chestId: "BrelshazaH4",
-    overrideMinIlvl: 1560,
-    hasNM: true
+    modes: [
+      {
+        name: "NM",
+        goldReward: 2500,
+        chestPrice: 1500,
+        HMThreashold: 1560
+      },
+      {
+        name: "HM",
+        goldReward: 3000,
+        chestPrice: 1800,
+        HMThreashold: Infinity
+      }
+    ]
   },
 
   // Abyss Raid - Kayangel
   {
-    name: "Kayangel Normal Gate 1",
-    goldReward: 1000,
+    name: "Kayangel Gate 1",
     taskName: "Kayangel",
-    chestPrice: 600,
     completionId: "T3.AR2.G1",
     chestId: "KayangelN1",
-    overrideMinIlvl: 1540,
-    overrideMaxIlvl: 1580
+    modes: [
+      {
+        name: "NM",
+        goldReward: 1000,
+        chestPrice: 600,
+        HMThreashold: 1580
+      },
+      {
+        name: "HM",
+        goldReward: 1500,
+        chestPrice: 700,
+        HMThreashold: Infinity
+      }
+    ]
   },
   {
-    name: "Kayangel Normal Gate 2",
-    goldReward: 1500,
+    name: "Kayangel Gate 2",
     taskName: "Kayangel",
-    chestPrice: 800,
     completionId: "T3.AR2.G2",
     chestId: "KayangelN2",
-    overrideMinIlvl: 1540,
-    overrideMaxIlvl: 1580
+    modes: [
+      {
+        name: "NM",
+        goldReward: 1500,
+        chestPrice: 800,
+        HMThreashold: 1580
+      },
+      {
+        name: "HM",
+        goldReward: 2000,
+        chestPrice: 900,
+        HMThreashold: Infinity
+      }
+    ]
   },
   {
-    name: "Kayangel Normal Gate 3",
-    goldReward: 2000,
+    name: "Kayangel Gate 3",
     taskName: "Kayangel",
-    chestPrice: 1000,
     completionId: "T3.AR2.G3",
     chestId: "KayangelN3",
-    overrideMinIlvl: 1540,
-    overrideMaxIlvl: 1580
-  },
-  {
-    name: "Kayangel Hard Gate 1",
-    goldReward: 1500,
-    taskName: "Kayangel",
-    chestPrice: 700,
-    completionId: "T3.AR2.G1",
-    chestId: "KayangelH1",
-    overrideMinIlvl: 1580,
-    hasNM: true
-  },
-  {
-    name: "Kayangel Hard Gate 2",
-    goldReward: 2000,
-    taskName: "Kayangel",
-    chestPrice: 900,
-    completionId: "T3.AR2.G2",
-    chestId: "KayangelH2",
-    overrideMinIlvl: 1580,
-    hasNM: true
-  },
-  {
-    name: "Kayangel Hard Gate 3",
-    goldReward: 3000,
-    taskName: "Kayangel",
-    chestPrice: 1100,
-    completionId: "T3.AR2.G3",
-    chestId: "KayangelH3",
-    overrideMinIlvl: 1580,
-    hasNM: true
+    modes: [
+      {
+        name: "NM",
+        goldReward: 2000,
+        chestPrice: 1000,
+        HMThreashold: 1580
+      },
+      {
+        name: "HM",
+        goldReward: 3000,
+        chestPrice: 1100,
+        HMThreashold: Infinity
+      }
+    ]
   },
 
   // Legion Raid - Akkan
   {
-    name: "Akkan Normal Gate 1",
-    goldReward: 1500,
+    name: "Akkan Gate 1",
     taskName: "Akkan",
-    chestPrice: 900,
     completionId: "T3.L5.G1",
     chestId: "AkkanN1",
-    overrideMinIlvl: 1580,
-    overrideMaxIlvl: 1600
+    modes: [
+      {
+        name: "NM",
+        goldReward: 1500,
+        chestPrice: 900,
+        HMThreashold: 1600
+      },
+      {
+        name: "HM",
+        goldReward: 1750,
+        chestPrice: 1200,
+        HMThreashold: Infinity
+      }
+    ]
   },
   {
-    name: "Akkan Normal Gate 2",
-    goldReward: 2000,
+    name: "Akkan Gate 2",
     taskName: "Akkan",
-    chestPrice: 1100,
     completionId: "T3.L5.G2",
     chestId: "AkkanN2",
-    overrideMinIlvl: 1580,
-    overrideMaxIlvl: 1600
+    modes: [
+      {
+        name: "NM",
+        goldReward: 2000,
+        chestPrice: 1100,
+        HMThreashold: 1600
+      },
+      {
+        name: "HM",
+        goldReward: 2500,
+        chestPrice: 1400,
+        HMThreashold: Infinity
+      }
+    ]
   },
   {
-    name: "Akkan Normal Gate 3",
-    goldReward: 4000,
+    name: "Akkan Gate 3",
     taskName: "Akkan",
-    chestPrice: 1500,
     completionId: "T3.L5.G3",
     chestId: "AkkanN3",
-    overrideMinIlvl: 1580,
-    overrideMaxIlvl: 1600
+    modes: [
+      {
+        name: "NM",
+        goldReward: 4000,
+        chestPrice: 1500,
+        HMThreashold: 1600
+      },
+      {
+        name: "HM",
+        goldReward: 5750,
+        chestPrice: 1900,
+        HMThreashold: Infinity
+      }
+    ]
+  },
+
+  // Abyss Raid - Ivory Tower - Voldis
+  {
+    name: "Ivory Tower Gate 1",
+    taskName: "Ivory Tower",
+    completionId: "T3.AR3.G1",
+    chestId: "IvoryTowerN1",
+    modes: [
+      {
+        name: "NM",
+        goldReward: 1500,
+        chestPrice: 700,
+        HMThreashold: 1620
+      },
+      {
+        name: "HM",
+        goldReward: 2000,
+        chestPrice: 1000,
+        HMThreashold: Infinity
+      }
+    ]
   },
   {
-  name: "Akkan Hard Gate 1",
-  goldReward: 1750,
-  taskName: "Akkan",
-  chestPrice: 1200,
-  completionId: "T3.L5.G1",
-  chestId: "AkkanH1",
-  overrideMinIlvl: 1600,
-  hasNM: true
-},
-{
-  name: "Akkan Hard Gate 2",
-  goldReward: 2500,
-  taskName: "Akkan",
-  chestPrice: 1400,
-  completionId: "T3.L5.G2",
-  chestId: "AkkanH2",
-  overrideMinIlvl: 1600,
-  hasNM: true
-},
-{
-  name: "Akkan Hard Gate 3",
-  goldReward: 5750,
-  taskName: "Akkan",
-  chestPrice: 1900,
-  completionId: "T3.L5.G3",
-  chestId: "AkkanH3",
-  overrideMinIlvl: 1600,
-  hasNM: true
-},
+    name: "Ivory Tower Gate 2",
+    taskName: "Ivory Tower",
+    completionId: "T3.AR3.G2",
+    chestId: "IvoryTowerN2",
+    modes: [
+      {
+        name: "NM",
+        goldReward: 1750,
+        chestPrice: 800,
+        HMThreashold: 1620
+      },
+      {
+        name: "HM",
+        goldReward: 2500,
+        chestPrice: 1000,
+        HMThreashold: Infinity
+      }
+    ]
+  },
+  {
+    name: "Ivory Tower Gate 3",
+    taskName: "Ivory Tower",
+    completionId: "T3.AR3.G3",
+    chestId: "IvoryTowerN3",
+    modes: [
+      {
+        name: "NM",
+        goldReward: 2500,
+        chestPrice: 900,
+        HMThreashold: 1620
+      },
+      {
+        name: "HM",
+        goldReward: 4000,
+        chestPrice: 1500,
+        HMThreashold: Infinity
+      }
+    ]
+  },
+  {
+    name: "Ivory Tower Gate 4",
+    taskName: "Ivory Tower",
+    completionId: "T3.AR3.G4",
+    chestId: "IvoryTowerN4",
+    modes: [
+      {
+        name: "NM",
+        goldReward: 3250,
+        chestPrice: 1100,
+        HMThreashold: 1620
+      },
+      {
+        name: "HM",
+        goldReward: 6000,
+        chestPrice: 2000,
+        HMThreashold: Infinity
+      }
+    ]
+  },
 
-// Abyss Raid - Ivory Tower - Voldis
-{
-  name: "Ivory Tower Normal Gate 1",
-  goldReward: 1500,
-  taskName: "Ivory Tower",
-  chestPrice: 700,
-  completionId: "T3.AR3.G1",
-  chestId: "IvoryTowerN1",
-  overrideMinIlvl: 1600,
-  overrideMaxIlvl: 1620
-},
-{
-  name: "Ivory Tower Normal Gate 2",
-  goldReward: 1750,
-  taskName: "Ivory Tower",
-  chestPrice: 800,
-  completionId: "T3.AR3.G2",
-  chestId: "IvoryTowerN2",
-  overrideMinIlvl: 1600,
-  overrideMaxIlvl: 1620
-},
-{
-  name: "Ivory Tower Normal Gate 3",
-  goldReward: 2500,
-  taskName: "Ivory Tower",
-  chestPrice: 900,
-  completionId: "T3.AR3.G3",
-  chestId: "IvoryTowerN3",
-  overrideMinIlvl: 1600,
-  overrideMaxIlvl: 1620
-},
-{
-  name: "Ivory Tower Normal Gate 4",
-  goldReward: 3250,
-  taskName: "Ivory Tower",
-  chestPrice: 1100,
-  completionId: "T3.AR3.G4",
-  chestId: "IvoryTowerN4",
-  overrideMinIlvl: 1600,
-  overrideMaxIlvl: 1620
-},
-{
-  name: "Ivory Tower Hard Gate 1",
-  goldReward: 2000,
-  taskName: "Ivory Tower",
-  chestPrice: 1000,
-  completionId: "T3.AR3.G1",
-  chestId: "IvoryTowerH1",
-  overrideMinIlvl: 1620,
-  hasNM: true
-},
-{
-  name: "Ivory Tower Hard Gate 2",
-  goldReward: 2500,
-  taskName: "Ivory Tower",
-  chestPrice: 1000,
-  completionId: "T3.AR3.G2",
-  chestId: "IvoryTowerH2",
-  overrideMinIlvl: 1620,
-  hasNM: true
-},
-{
-  name: "Ivory Tower Hard Gate 3",
-  goldReward: 4000,
-  taskName: "Ivory Tower",
-  chestPrice: 1500,
-  completionId: "T3.AR3.G3",
-  chestId: "IvoryTowerH3",
-  overrideMinIlvl: 1620,
-  hasNM: true
-},
-{
-  name: "Ivory Tower Hard Gate 4",
-  goldReward: 6000,
-  taskName: "Ivory Tower",
-  chestPrice: 2000,
-  completionId: "T3.AR3.G4",
-  chestId: "IvoryTowerH4",
-  overrideMinIlvl: 1620,
-  hasNM: true
-},
+  // Legion Raid - Thaemine
+  {
+    name: "Thaemine Gate 1",
+    taskName: "Thaemine",
+    completionId: "T3.L6.G1",
+    chestId: "ThaemineN1",
+    modes: [
+      {
+        name: "NM",
+        goldReward: 3500,
+        chestPrice: 1500,
+        HMThreashold: 1630
+      },
+      {
+        name: "HM",
+        goldReward: 5000,
+        chestPrice: 2000,
+        HMThreashold: Infinity
+      }
+    ]
+  },
+  {
+    name: "Thaemine Gate 2",
+    taskName: "Thaemine",
+    completionId: "T3.L6.G2",
+    chestId: "ThaemineN2",
+    modes: [
+      {
+        name: "NM",
+        goldReward: 4000,
+        chestPrice: 1800,
+        HMThreashold: 1630
+      },
+      {
+        name: "HM",
+        goldReward: 6000,
+        chestPrice: 2400,
+        HMThreashold: Infinity
+      }
+    ]
+  },
+  {
+    name: "Thaemine Gate 3",
+    taskName: "Thaemine",
+    completionId: "T3.L6.G3",
+    chestId: "ThaemineN3",
+    modes: [
+      {
+        name: "NM",
+        goldReward: 5500,
+        chestPrice: 2500,
+        HMThreashold: 1630
+      },
+      {
+        name: "HM",
+        goldReward: 9000,
+        chestPrice: 2800,
+        HMThreashold: Infinity
+      }
+    ]
+  },
+  {
+    name: "Thaemine Gate 4",
+    taskName: "Thaemine G4",
+    completionId: "T3.L6.G4",
+    chestId: "ThaemineH4",
+    modes: [
+      {
+        name: "NM", // We set it to NM because there is only 1 difficulty, even though it's Hard Mode in game
+        goldReward: 21000,
+        chestPrice: 3600,
+        HMThreashold: Infinity
+      }
+    ]
+  },
 
-// Legion Raid - Thaemine
-{
-  name: "Thaemine Normal Gate 1",
-  goldReward: 3500,
-  taskName: "Thaemine",
-  chestPrice: 1500,
-  completionId: "T3.L6.G1",
-  chestId: "ThaemineN1",
-  overrideMinIlvl: 1610,
-  overrideMaxIlvl: 1630
-},
-{
-  name: "Thaemine Normal Gate 2",
-  goldReward: 4000,
-  taskName: "Thaemine",
-  chestPrice: 1800,
-  completionId: "T3.L6.G2",
-  chestId: "ThaemineN2",
-  overrideMinIlvl: 1610,
-  overrideMaxIlvl: 1630
-},
-{
-  name: "Thaemine Normal Gate 3",
-  goldReward: 5500,
-  taskName: "Thaemine",
-  chestPrice: 2500,
-  completionId: "T3.L6.G3",
-  chestId: "ThaemineN3",
-  overrideMinIlvl: 1610,
-  overrideMaxIlvl: 1630
-},
-{
-  name: "Thaemine Hard Gate 1",
-  goldReward: 5000,
-  taskName: "Thaemine",
-  chestPrice: 2000,
-  completionId: "T3.L6.G1",
-  chestId: "ThaemineH1",
-  overrideMinIlvl: 1630,
-  hasNM: true
-},
-{
-  name: "Thaemine Hard Gate 2",
-  goldReward: 6000,
-  taskName: "Thaemine",
-  chestPrice: 2400,
-  completionId: "T3.L6.G2",
-  chestId: "ThaemineH2",
-  overrideMinIlvl: 1630,
-  hasNM: true
-},
-{
-  name: "Thaemine Hard Gate 3",
-  goldReward: 9000,
-  taskName: "Thaemine",
-  chestPrice: 2800,
-  completionId: "T3.L6.G3",
-  chestId: "ThaemineH3",
-  overrideMinIlvl: 1630,
-  hasNM: true
-},
-{
-  name: "Thaemine Hard Gate 4",
-  goldReward: 21000,
-  taskName: "Thaemine G4",
-  chestPrice: 3600,
-  completionId: "T3.L6.G4",
-  chestId: "ThaemineH4",
-  overrideMinIlvl: 1630
-},
-
-// Kazeros Raid
-{
-  name: "Echidna Normal Gate 1",
-  goldReward: 5000,
-  taskName: "Echidna",
-  chestPrice: 2200,
-  completionId: "T3.K1.G1",
-  chestId: "EchidnaN1",
-  overrideMinIlvl: 1620,
-  overrideMaxIlvl: 1630
-},
-{
-  name: "Echidna Normal Gate 2",
-  goldReward: 9500,
-  taskName: "Echidna",
-  chestPrice: 3400,
-  completionId: "T3.K1.G2",
-  chestId: "EchidnaN2",
-  overrideMinIlvl: 1620,
-  overrideMaxIlvl: 1630
-},
-{
-  name: "Echidna Hard Gate 1",
-  goldReward: 6000,
-  taskName: "Echidna",
-  chestPrice: 2800,
-  completionId: "T3.K1.G1",
-  chestId: "EchidnaH1",
-  overrideMinIlvl: 1630,
-  hasNM: true
-},
-{
-  name: "Echidna Hard Gate 2",
-  goldReward: 12500,
-  taskName: "Echidna",
-  chestPrice: 4100,
-  completionId: "T3.K1.G2",
-  chestId: "EchidnaH2",
-  overrideMinIlvl: 1630,
-  hasNM: true
-}
+  // Kazeros Raid
+  {
+    name: "Echidna Gate 1",
+    taskName: "Echidna",
+    completionId: "T3.K1.G1",
+    chestId: "EchidnaN1",
+    modes: [
+      {
+        name: "NM",
+        goldReward: 5000,
+        chestPrice: 2200,
+        HMThreashold: 1630
+      },
+      {
+        name: "HM",
+        goldReward: 6000,
+        chestPrice: 2800,
+        HMThreashold: Infinity
+      }
+    ]
+  },
+  {
+    name: "Echidna Gate 2",
+    taskName: "Echidna",
+    completionId: "T3.K1.G2",
+    chestId: "EchidnaN2",
+    modes: [
+      {
+        name: "NM",
+        goldReward: 9500,
+        chestPrice: 3400,
+        HMThreashold: 1630
+      },
+      {
+        name: "HM",
+        goldReward: 12500,
+        chestPrice: 4100,
+        HMThreashold: Infinity
+      }
+    ]
+  }
 ];

--- a/apps/client/src/app/pages/gold-planner/gold-tasks.ts
+++ b/apps/client/src/app/pages/gold-planner/gold-tasks.ts
@@ -2,80 +2,78 @@ import { GoldTask } from "./gold-task";
 
 export const goldTasks: GoldTask[] = [
 
-  // T1 Abyss
+  // T2 Abyss Dungeon
   {
     name: "Demon Beast Canyon",
     goldReward: 80,
     taskName: "Demon Beast Canyon",
     chestPrice: 30,
-    completionId: "T1.1"
+    completionId: "T2.A1.G1"
   },
   {
     name: "Necromancer's Origin",
     goldReward: 80,
     taskName: "Necromancer's Origin",
     chestPrice: 30,
-    completionId: "T1.1"
+    completionId: "T2.A1.G2"
   },
   {
     name: "Hall of the Twisted Warlord",
     goldReward: 80,
     taskName: "Hall of the Twisted Warlord",
     chestPrice: 30,
-    completionId: "T1.2"
+    completionId: "T2.A2.G1"
   },
   {
     name: "Hildebrandt Palace",
     goldReward: 80,
     taskName: "Hildebrandt Palace",
     chestPrice: 30,
-    completionId: "T1.2"
+    completionId: "T2.A2.G2"
   },
-
-  // T2 Abyss
   {
     name: "Road of Lament",
     goldReward: 100,
     taskName: "Road of Lament",
     chestPrice: 40,
-    completionId: "T2.1"
+    completionId: "T2.A3.G1"
   },
   {
     name: "Forge of Fallen Pride",
     goldReward: 100,
     taskName: "Forge of Fallen Pride",
     chestPrice: 40,
-    completionId: "T2.1"
+    completionId: "T2.A3.G2"
   },
   {
     name: "Sea of Indolence",
     goldReward: 100,
     taskName: "Sea of Indolence",
     chestPrice: 40,
-    completionId: "T2.2"
+    completionId: "T2.A4.G1"
   },
   {
     name: "Tranquil Karkosa",
     goldReward: 100,
     taskName: "Tranquil Karkosa",
     chestPrice: 40,
-    completionId: "T2.2"
+    completionId: "T2.A4.G2"
   },
   {
     name: "Alaric's Sanctuary",
     goldReward: 100,
     taskName: "Alaric's Sanctuary",
     chestPrice: 40,
-    completionId: "T2.2"
+    completionId: "T2.A4.G3"
   },
 
-  // T3 Abyss
+  // T3 Abyss Dungeon - ilvl below Argos
   {
     name: "Aira's Oculus (Normal)",
     goldReward: 200,
     taskName: "Aira's Oculus",
     chestPrice: 100,
-    completionId: "T3.1",
+    completionId: "T3.A1.G1",
     entryId: "T3.1.0"
   },
   {
@@ -83,7 +81,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 300,
     taskName: "Oreha Preveza",
     chestPrice: 150,
-    completionId: "T3.1",
+    completionId: "T3.A1.G2",
     entryId: "T3.1.1"
   },
   {
@@ -91,27 +89,29 @@ export const goldTasks: GoldTask[] = [
     goldReward: 300,
     taskName: "Aira's Oculus",
     chestPrice: 100,
-    completionId: "T3.1",
+    completionId: "T3.A1.G1",
     entryId: "T3.1.0",
-    overrideMinIlvl: 1370
+    overrideMinIlvl: 1370,
+    hasNM: true
   },
   {
     name: "Oreha Preveza (Hard)",
     goldReward: 400,
     taskName: "Oreha Preveza",
     chestPrice: 150,
-    completionId: "T3.1",
+    completionId: "T3.A1.G2",
     entryId: "T3.1.1",
-    overrideMinIlvl: 1370
+    overrideMinIlvl: 1370,
+    hasNM: true
   },
 
-  // T3 Abyss Raid
+  // T3 Abyss Raid - Argos
   {
     name: "Argos Gate 1",
     goldReward: 300,
     taskName: "Argos",
     chestPrice: 100,
-    completionId: "T3.L1.1",
+    completionId: "T3.AR1.G1",
     overrideMaxIlvl: 1475,
     chestId: "Argos1"
   },
@@ -120,7 +120,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 300,
     taskName: "Argos",
     chestPrice: 150,
-    completionId: "T3.L1.2",
+    completionId: "T3.AR1.G2",
     chestId: "Argos2",
     overrideMaxIlvl: 1475,
   },
@@ -129,7 +129,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 400,
     taskName: "Argos",
     chestPrice: 150,
-    completionId: "T3.L1.3",
+    completionId: "T3.AR1.G3",
     chestId: "Argos3",
     overrideMaxIlvl: 1475,
   },
@@ -140,7 +140,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 500,
     taskName: "Valtan",
     chestPrice: 300,
-    completionId: "T3.L1.1",
+    completionId: "T3.L1.G1",
     chestId: "Valtan1",
     overrideMaxIlvl: 1445
   },
@@ -149,7 +149,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 700,
     taskName: "Valtan",
     chestPrice: 400,
-    completionId: "T3.L1.2",
+    completionId: "T3.L1.G2",
     chestId: "Valtan2",
     overrideMaxIlvl: 1445
   },
@@ -158,25 +158,27 @@ export const goldTasks: GoldTask[] = [
     goldReward: 700,
     taskName: "Valtan",
     chestPrice: 450,
-    completionId: "T3.L1.1",
+    completionId: "T3.L1.G1",
     chestId: "Valtan1",
-    overrideMinIlvl: 1445
+    overrideMinIlvl: 1445,
+    hasNM: true
   },
   {
     name: "Valtan Hard Gate 2",
     goldReward: 1100,
     taskName: "Valtan",
     chestPrice: 600,
-    completionId: "T3.L1.2",
+    completionId: "T3.L1.G2",
     chestId: "Valtan2",
-    overrideMinIlvl: 1445
+    overrideMinIlvl: 1445,
+    hasNM: true
   },
   {
     name: "Vykas Normal Gate 1",
     goldReward: 600,
     taskName: "Vykas",
     chestPrice: 300,
-    completionId: "T3.L2.1",
+    completionId: "T3.L2.G1",
     chestId: "Vykas1",
     overrideMaxIlvl: 1460
   },
@@ -185,7 +187,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 1000,
     taskName: "Vykas",
     chestPrice: 450,
-    completionId: "T3.L2.2",
+    completionId: "T3.L2.G2",
     chestId: "Vykas2",
     overrideMaxIlvl: 1460
   },
@@ -194,25 +196,27 @@ export const goldTasks: GoldTask[] = [
     goldReward: 900,
     taskName: "Vykas",
     chestPrice: 500,
-    completionId: "T3.L2.1",
+    completionId: "T3.L2.G1",
     chestId: "Vykas1",
-    overrideMinIlvl: 1460
+    overrideMinIlvl: 1460,
+    hasNM: true
   },
   {
     name: "Vykas Hard Gate 2",
     goldReward: 1500,
     taskName: "Vykas",
     chestPrice: 650,
-    completionId: "T3.L2.2",
+    completionId: "T3.L2.G2",
     chestId: "Vykas2",
-    overrideMinIlvl: 1460
+    overrideMinIlvl: 1460,
+    hasNM: true
   },
   {
     name: "Kakul-Saydon Gate 1",
     goldReward: 600,
     taskName: "Kakul-Saydon",
     chestPrice: 300,
-    completionId: "T3.L3.1",
+    completionId: "T3.L3.G1",
     chestId: "Kakul1",
     overrideMinIlvl: 1475
   },
@@ -221,7 +225,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 900,
     taskName: "Kakul-Saydon",
     chestPrice: 500,
-    completionId: "T3.L3.2",
+    completionId: "T3.L3.G2",
     chestId: "Kakul2",
     overrideMinIlvl: 1475
   },
@@ -230,7 +234,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 1500,
     taskName: "Kakul-Saydon",
     chestPrice: 700,
-    completionId: "T3.L3.3",
+    completionId: "T3.L3.G3",
     chestId: "Kakul3",
     overrideMinIlvl: 1475
   },
@@ -239,7 +243,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 2000,
     taskName: "Brelshaza Gate 1-2",
     chestPrice: 400,
-    completionId: "T3.L4.1",
+    completionId: "T3.L4.G1",
     chestId: "BrelshazaN1",
     overrideMinIlvl: 1490,
     overrideMaxIlvl: 1540
@@ -249,7 +253,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 2500,
     taskName: "Brelshaza Gate 1-2",
     chestPrice: 600,
-    completionId: "T3.L4.2",
+    completionId: "T3.L4.G2",
     chestId: "BrelshazaN2",
     overrideMinIlvl: 1490,
     overrideMaxIlvl: 1540
@@ -259,7 +263,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 1500,
     taskName: "Brelshaza Gate 3",
     chestPrice: 800,
-    completionId: "T3.L4.3",
+    completionId: "T3.L4.G3",
     chestId: "BrelshazaN3",
     overrideMinIlvl: 1500,
     overrideMaxIlvl: 1550
@@ -269,7 +273,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 2500,
     taskName: "Brelshaza Gate 4",
     chestPrice: 1500,
-    completionId: "T3.L4.4",
+    completionId: "T3.L4.G4",
     chestId: "BrelshazaN4",
     overrideMinIlvl: 1520,
     overrideMaxIlvl: 1560
@@ -279,43 +283,49 @@ export const goldTasks: GoldTask[] = [
     goldReward: 2500,
     taskName: "Brelshaza Gate 1-2",
     chestPrice: 700,
-    completionId: "T3.L5.1",
+    completionId: "T3.L4.G1",
     chestId: "BrelshazaH1",
-    overrideMinIlvl: 1540
+    overrideMinIlvl: 1540,
+    hasNM: true
     },
   {
     name: "Brelshaza Hard Gate 2",
     goldReward: 3000,
     taskName: "Brelshaza Gate 1-2",
     chestPrice: 900,
-    completionId: "T3.L5.2",
+    completionId: "T3.L4.G2",
     chestId: "BrelshazaH2",
-    overrideMinIlvl: 1540
+    overrideMinIlvl: 1540,
+    hasNM: true
   },
   {
     name: "Brelshaza Hard Gate 3",
     goldReward: 2000,
     taskName: "Brelshaza Gate 3",
     chestPrice: 1100,
-    completionId: "T3.L5.3",
+    completionId: "T3.L4.G3",
     chestId: "BrelshazaH3",
-    overrideMinIlvl: 1550
+    overrideMinIlvl: 1550,
+    hasNM: true
   },
   {
     name: "Brelshaza Hard Gate 4",
     goldReward: 3000,
     taskName: "Brelshaza Gate 4",
     chestPrice: 1800,
-    completionId: "T3.L5.4",
+    completionId: "T3.L4.G4",
     chestId: "BrelshazaH4",
-    overrideMinIlvl: 1560
+    overrideMinIlvl: 1560,
+    hasNM: true
   },
+
+  // Abyss Raid - Kayangel
   {
     name: "Kayangel Normal Gate 1",
     goldReward: 1000,
     taskName: "Kayangel",
     chestPrice: 600,
-    completionId: "T3.L6.1",
+    completionId: "T3.AR2.G1",
     chestId: "KayangelN1",
     overrideMinIlvl: 1540,
     overrideMaxIlvl: 1580
@@ -325,7 +335,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 1500,
     taskName: "Kayangel",
     chestPrice: 800,
-    completionId: "T3.L6.2",
+    completionId: "T3.AR2.G2",
     chestId: "KayangelN2",
     overrideMinIlvl: 1540,
     overrideMaxIlvl: 1580
@@ -335,7 +345,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 2000,
     taskName: "Kayangel",
     chestPrice: 1000,
-    completionId: "T3.L6.3",
+    completionId: "T3.AR2.G3",
     chestId: "KayangelN3",
     overrideMinIlvl: 1540,
     overrideMaxIlvl: 1580
@@ -345,34 +355,39 @@ export const goldTasks: GoldTask[] = [
     goldReward: 1500,
     taskName: "Kayangel",
     chestPrice: 700,
-    completionId: "T3.L7.1",
+    completionId: "T3.AR2.G1",
     chestId: "KayangelH1",
-    overrideMinIlvl: 1580
+    overrideMinIlvl: 1580,
+    hasNM: true
   },
   {
     name: "Kayangel Hard Gate 2",
     goldReward: 2000,
     taskName: "Kayangel",
     chestPrice: 900,
-    completionId: "T3.L7.2",
+    completionId: "T3.AR2.G2",
     chestId: "KayangelH2",
-    overrideMinIlvl: 1580
+    overrideMinIlvl: 1580,
+    hasNM: true
   },
   {
     name: "Kayangel Hard Gate 3",
     goldReward: 3000,
     taskName: "Kayangel",
     chestPrice: 1100,
-    completionId: "T3.L7.3",
+    completionId: "T3.AR2.G3",
     chestId: "KayangelH3",
-    overrideMinIlvl: 1580
+    overrideMinIlvl: 1580,
+    hasNM: true
   },
+
+  // Legion Raid - Akkan
   {
     name: "Akkan Normal Gate 1",
     goldReward: 1500,
     taskName: "Akkan",
     chestPrice: 900,
-    completionId: "T3.L8.1",
+    completionId: "T3.L5.G1",
     chestId: "AkkanN1",
     overrideMinIlvl: 1580,
     overrideMaxIlvl: 1600
@@ -382,7 +397,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 2000,
     taskName: "Akkan",
     chestPrice: 1100,
-    completionId: "T3.L8.2",
+    completionId: "T3.L5.G2",
     chestId: "AkkanN2",
     overrideMinIlvl: 1580,
     overrideMaxIlvl: 1600
@@ -392,7 +407,7 @@ export const goldTasks: GoldTask[] = [
     goldReward: 4000,
     taskName: "Akkan",
     chestPrice: 1500,
-    completionId: "T3.L8.3",
+    completionId: "T3.L5.G3",
     chestId: "AkkanN3",
     overrideMinIlvl: 1580,
     overrideMaxIlvl: 1600
@@ -402,34 +417,39 @@ export const goldTasks: GoldTask[] = [
   goldReward: 1750,
   taskName: "Akkan",
   chestPrice: 1200,
-  completionId: "T3.L9.1",
+  completionId: "T3.L5.G1",
   chestId: "AkkanH1",
-  overrideMinIlvl: 1600
+  overrideMinIlvl: 1600,
+  hasNM: true
 },
 {
   name: "Akkan Hard Gate 2",
   goldReward: 2500,
   taskName: "Akkan",
   chestPrice: 1400,
-  completionId: "T3.L9.2",
+  completionId: "T3.L5.G2",
   chestId: "AkkanH2",
-  overrideMinIlvl: 1600
+  overrideMinIlvl: 1600,
+  hasNM: true
 },
 {
   name: "Akkan Hard Gate 3",
   goldReward: 5750,
   taskName: "Akkan",
   chestPrice: 1900,
-  completionId: "T3.L9.3",
+  completionId: "T3.L5.G3",
   chestId: "AkkanH3",
-  overrideMinIlvl: 1600
+  overrideMinIlvl: 1600,
+  hasNM: true
 },
+
+// Abyss Raid - Ivory Tower - Voldis
 {
   name: "Ivory Tower Normal Gate 1",
   goldReward: 1500,
   taskName: "Ivory Tower",
   chestPrice: 700,
-  completionId: "T3.L10.1",
+  completionId: "T3.AR3.G1",
   chestId: "IvoryTowerN1",
   overrideMinIlvl: 1600,
   overrideMaxIlvl: 1620
@@ -439,7 +459,7 @@ export const goldTasks: GoldTask[] = [
   goldReward: 1750,
   taskName: "Ivory Tower",
   chestPrice: 800,
-  completionId: "T3.L10.2",
+  completionId: "T3.AR3.G2",
   chestId: "IvoryTowerN2",
   overrideMinIlvl: 1600,
   overrideMaxIlvl: 1620
@@ -449,7 +469,7 @@ export const goldTasks: GoldTask[] = [
   goldReward: 2500,
   taskName: "Ivory Tower",
   chestPrice: 900,
-  completionId: "T3.L10.3",
+  completionId: "T3.AR3.G3",
   chestId: "IvoryTowerN3",
   overrideMinIlvl: 1600,
   overrideMaxIlvl: 1620
@@ -459,7 +479,7 @@ export const goldTasks: GoldTask[] = [
   goldReward: 3250,
   taskName: "Ivory Tower",
   chestPrice: 1100,
-  completionId: "T3.L10.4",
+  completionId: "T3.AR3.G4",
   chestId: "IvoryTowerN4",
   overrideMinIlvl: 1600,
   overrideMaxIlvl: 1620
@@ -469,43 +489,49 @@ export const goldTasks: GoldTask[] = [
   goldReward: 2000,
   taskName: "Ivory Tower",
   chestPrice: 1000,
-  completionId: "T3.L11.1",
+  completionId: "T3.AR3.G1",
   chestId: "IvoryTowerH1",
-  overrideMinIlvl: 1620
+  overrideMinIlvl: 1620,
+  hasNM: true
 },
 {
   name: "Ivory Tower Hard Gate 2",
   goldReward: 2500,
   taskName: "Ivory Tower",
   chestPrice: 1000,
-  completionId: "T3.L11.2",
+  completionId: "T3.AR3.G2",
   chestId: "IvoryTowerH2",
-  overrideMinIlvl: 1620
+  overrideMinIlvl: 1620,
+  hasNM: true
 },
 {
   name: "Ivory Tower Hard Gate 3",
   goldReward: 4000,
   taskName: "Ivory Tower",
   chestPrice: 1500,
-  completionId: "T3.L11.3",
+  completionId: "T3.AR3.G3",
   chestId: "IvoryTowerH3",
-  overrideMinIlvl: 1620
+  overrideMinIlvl: 1620,
+  hasNM: true
 },
 {
   name: "Ivory Tower Hard Gate 4",
   goldReward: 6000,
   taskName: "Ivory Tower",
   chestPrice: 2000,
-  completionId: "T3.L11.4",
+  completionId: "T3.AR3.G4",
   chestId: "IvoryTowerH4",
-  overrideMinIlvl: 1620
+  overrideMinIlvl: 1620,
+  hasNM: true
 },
+
+// Legion Raid - Thaemine
 {
   name: "Thaemine Normal Gate 1",
   goldReward: 3500,
   taskName: "Thaemine",
   chestPrice: 1500,
-  completionId: "T3.L12.1",
+  completionId: "T3.L6.G1",
   chestId: "ThaemineN1",
   overrideMinIlvl: 1610,
   overrideMaxIlvl: 1630
@@ -515,7 +541,7 @@ export const goldTasks: GoldTask[] = [
   goldReward: 4000,
   taskName: "Thaemine",
   chestPrice: 1800,
-  completionId: "T3.L12.2",
+  completionId: "T3.L6.G2",
   chestId: "ThaemineN2",
   overrideMinIlvl: 1610,
   overrideMaxIlvl: 1630
@@ -525,7 +551,7 @@ export const goldTasks: GoldTask[] = [
   goldReward: 5500,
   taskName: "Thaemine",
   chestPrice: 2500,
-  completionId: "T3.L12.3",
+  completionId: "T3.L6.G3",
   chestId: "ThaemineN3",
   overrideMinIlvl: 1610,
   overrideMaxIlvl: 1630
@@ -535,43 +561,48 @@ export const goldTasks: GoldTask[] = [
   goldReward: 5000,
   taskName: "Thaemine",
   chestPrice: 2000,
-  completionId: "T3.L13.1",
+  completionId: "T3.L6.G1",
   chestId: "ThaemineH1",
-  overrideMinIlvl: 1630
+  overrideMinIlvl: 1630,
+  hasNM: true
 },
 {
   name: "Thaemine Hard Gate 2",
   goldReward: 6000,
   taskName: "Thaemine",
   chestPrice: 2400,
-  completionId: "T3.L13.2",
+  completionId: "T3.L6.G2",
   chestId: "ThaemineH2",
-  overrideMinIlvl: 1630
+  overrideMinIlvl: 1630,
+  hasNM: true
 },
 {
   name: "Thaemine Hard Gate 3",
   goldReward: 9000,
   taskName: "Thaemine",
   chestPrice: 2800,
-  completionId: "T3.L13.3",
+  completionId: "T3.L6.G3",
   chestId: "ThaemineH3",
-  overrideMinIlvl: 1630
+  overrideMinIlvl: 1630,
+  hasNM: true
 },
 {
   name: "Thaemine Hard Gate 4",
   goldReward: 21000,
   taskName: "Thaemine G4",
   chestPrice: 3600,
-  completionId: "T3.L13.4",
+  completionId: "T3.L6.G4",
   chestId: "ThaemineH4",
   overrideMinIlvl: 1630
 },
+
+// Kazeros Raid
 {
   name: "Echidna Normal Gate 1",
   goldReward: 5000,
   taskName: "Echidna",
   chestPrice: 2200,
-  completionId: "T3.L14.1",
+  completionId: "T3.K1.G1",
   chestId: "EchidnaN1",
   overrideMinIlvl: 1620,
   overrideMaxIlvl: 1630
@@ -581,7 +612,7 @@ export const goldTasks: GoldTask[] = [
   goldReward: 9500,
   taskName: "Echidna",
   chestPrice: 3400,
-  completionId: "T3.L14.2",
+  completionId: "T3.K1.G2",
   chestId: "EchidnaN2",
   overrideMinIlvl: 1620,
   overrideMaxIlvl: 1630
@@ -591,17 +622,19 @@ export const goldTasks: GoldTask[] = [
   goldReward: 6000,
   taskName: "Echidna",
   chestPrice: 2800,
-  completionId: "T3.L15.1",
+  completionId: "T3.K1.G1",
   chestId: "EchidnaH1",
-  overrideMinIlvl: 1630
+  overrideMinIlvl: 1630,
+  hasNM: true
 },
 {
   name: "Echidna Hard Gate 2",
   goldReward: 12500,
   taskName: "Echidna",
   chestPrice: 4100,
-  completionId: "T3.L15.2",
+  completionId: "T3.K1.G2",
   chestId: "EchidnaH2",
-  overrideMinIlvl: 1630
+  overrideMinIlvl: 1630,
+  hasNM: true
 }
 ];


### PR DESCRIPTION
NM and HM lines for a single gate now merged in a single line. 
![image](https://github.com/user-attachments/assets/a4eeed40-d56e-404b-9736-d047703cc099)


You select if you count NM or HM gold reward/chest price using a toggle. The toggle appears only if you can run HM with that character
![image](https://github.com/user-attachments/assets/e0ecbe9f-18dd-45d8-9716-dc2db07fe80f)


Updated chest prices for T2 dungeons (costs silver, so new gold price is 0)

Small code refactor to reduce code clutter

Adding Solo Raid mode/gold info should be easy (fingers crossed)