### PR TITLE
Gold planner - Toggle between full planning and remaining for the week

### DIFF
--- a/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.html
+++ b/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.html
@@ -7,6 +7,13 @@
   <ng-container *ngIf="roster$ | async as roster">
     <ng-container *ngIf="scrolling$ | async as scrolling">
       <div class="chest-matrix" *ngIf="display$ | async as display">
+          <div class="switch-container">
+            <nz-switch nzCheckedChildren="Remaining for the week"
+                      nzUnCheckedChildren="Full Planning"
+                      [ngModel]="display.tracking['hideAlreadyDoneTasks']"
+                      (ngModelChange)="setHideAlreadyDoneTasksFlag(settings.$key, display.tracking, $event)"
+                      ></nz-switch>
+          </div>
         <nz-table #tasksTable
                   [nzData]="display.chestsData"
                   [nzPageSize]="999"

--- a/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.ts
+++ b/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.ts
@@ -6,6 +6,7 @@ import { LostarkTask } from "../../../model/lostark-task";
 import { RosterService } from "../../../core/database/services/roster.service";
 import { SettingsService } from "../../../core/database/services/settings.service";
 import { TasksService } from "../../../core/database/services/tasks.service";
+import { CompletionService } from '../../../core/database/services/completion.service';
 import { Character } from "../../../model/character/character";
 import { TimeService } from "../../../core/time.service";
 import { ManualWeeklyGoldEntry, Settings } from "../../../model/settings";
@@ -47,6 +48,7 @@ export class GoldPlannerComponent {
   public settings$ = this.settings.settings$;
 
   public tasks$ = this.tasksService.tasks$;
+  public completion$ = this.completionService.completion$;
 
   public tracking$ = this.settings.settings$.pipe(pluck("goldPlannerConfiguration"));
   public manualGoldEntries$ = this.settings.settings$.pipe(pluck("manualGoldEntries"));
@@ -58,9 +60,10 @@ export class GoldPlannerComponent {
     of(goldTasks),
     this.manualGoldEntries$,
     this.timeService.lastWeeklyReset$,
-    this.rawRoster$
+    this.rawRoster$,
+    this.completion$
   ]).pipe(
-    map(([roster, tasks, tracking, gTasks, manualGoldEntries, weeklyReset, rawRoster]) => {
+    map(([roster, tasks, tracking, gTasks, manualGoldEntries, weeklyReset, rawRoster, completion]) => {
       const chestsData = gTasks
         .map(gTask => {
           const task = tasks.find(t => t.label === gTask.taskName && !t.custom);
@@ -75,6 +78,11 @@ export class GoldPlannerComponent {
         })
         .map(({ gTask, task }) => {
           const goldDetails = roster.map((character) => {
+
+            const completionFlag = task && getCompletionEntry(completion.data, character, task);
+            const gateAlreadyDone = completionFlag && completionFlag.amount >= parseInt(gTask.completionId.substring(gTask.completionId.length - 1))
+            const hideAlreadyDoneGate = tracking['hideAlreadyDoneTasks'] && gateAlreadyDone === true
+
             const cantDoTask = task && (!task.enabled || character.ilvl < (task.minIlvl || 0) || character.ilvl >= (task.maxIlvl || Infinity));
             const goldChestflag = tracking[this.getGoldChestFlag(character.name, gTask)];
             const takingGoldFlag = tracking[this.getGoldTakingFlag(character.name, gTask)];
@@ -83,7 +91,7 @@ export class GoldPlannerComponent {
             const chosenMode = gTask.modes && gTask.modes.find(mode => (runningHFlag === true || runningHFlag === undefined) ? mode.name === 'NM' : mode.name === 'HM')
 
             const goldDetail = {
-              hide: false || cantDoTask || !character.weeklyGold || (task ? getCompletionEntry(rawRoster.trackedTasks, character, task, true) === false : false),
+              hide: false || cantDoTask || !character.weeklyGold || (task ? getCompletionEntry(rawRoster.trackedTasks, character, task, true) === false : false) || hideAlreadyDoneGate,
               takingChest: goldChestflag === undefined ? true : goldChestflag,
               takingGold: takingGoldFlag === undefined ? true : takingGoldFlag,
               runningHM: runningHFlag === undefined ? true : runningHFlag,
@@ -125,14 +133,16 @@ export class GoldPlannerComponent {
         .reduce((acc, row) => {
           const { goldDetails } = row;
           goldDetails.forEach((flag, i) => {
-            // True = skip gold, False = take gold
-            if (flag.takingGold === false) {
-              acc[i] += flag.goldReward
-            }
+            if (!flag.hide) {
+              // True = skip gold, False = take gold
+              if (flag.takingGold === false) {
+                acc[i] += flag.goldReward
+              }
 
-            // True = skip chest, False = take chest
-            if (flag.takingChest === false) {
-              acc[i] -= flag.chestPrice
+              // True = skip chest, False = take chest
+              if (flag.takingChest === false) {
+                acc[i] -= flag.chestPrice
+              }
             }
           });
           return acc;
@@ -173,7 +183,8 @@ export class GoldPlannerComponent {
   constructor(private rosterService: RosterService,
     private tasksService: TasksService,
     private settings: SettingsService,
-    private timeService: TimeService) {
+    private timeService: TimeService,
+    private completionService: CompletionService) {
   }
 
   private getGoldChestFlag(characterName: string, gTask: GoldTask): string {

--- a/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.ts
+++ b/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.ts
@@ -240,6 +240,14 @@ export class GoldPlannerComponent {
     });
   }
 
+  setHideAlreadyDoneTasksFlag(settingsKey: string, tracking: Record<string, boolean>, flag: boolean): void {
+    tracking['hideAlreadyDoneTasks'] = flag;
+    this.settings.patch({
+      $key: settingsKey,
+      goldPlannerConfiguration: tracking
+    });
+  }
+
   trackByIndex(index: number): number {
     return index;
   }

--- a/apps/client/src/app/pages/gold-planner/gold-tasks.ts
+++ b/apps/client/src/app/pages/gold-planner/gold-tasks.ts
@@ -371,7 +371,7 @@ export const goldTasks: GoldTask[] = [
   {
     name: "Brelshaza Gate 3",
     taskName: "Brelshaza Gate 3",
-    completionId: "T3.L4.G3",
+    completionId: "T3.L5.G1",
     chestId: "BrelshazaN3",
     modes: [
       {
@@ -391,7 +391,7 @@ export const goldTasks: GoldTask[] = [
   {
     name: "Brelshaza Gate 4",
     taskName: "Brelshaza Gate 4",
-    completionId: "T3.L4.G4",
+    completionId: "T3.L6.G1",
     chestId: "BrelshazaN4",
     modes: [
       {
@@ -475,7 +475,7 @@ export const goldTasks: GoldTask[] = [
   {
     name: "Akkan Gate 1",
     taskName: "Akkan",
-    completionId: "T3.L5.G1",
+    completionId: "T3.L7.G1",
     chestId: "AkkanN1",
     modes: [
       {
@@ -495,7 +495,7 @@ export const goldTasks: GoldTask[] = [
   {
     name: "Akkan Gate 2",
     taskName: "Akkan",
-    completionId: "T3.L5.G2",
+    completionId: "T3.L7.G2",
     chestId: "AkkanN2",
     modes: [
       {
@@ -515,7 +515,7 @@ export const goldTasks: GoldTask[] = [
   {
     name: "Akkan Gate 3",
     taskName: "Akkan",
-    completionId: "T3.L5.G3",
+    completionId: "T3.L7.G3",
     chestId: "AkkanN3",
     modes: [
       {
@@ -619,7 +619,7 @@ export const goldTasks: GoldTask[] = [
   {
     name: "Thaemine Gate 1",
     taskName: "Thaemine",
-    completionId: "T3.L6.G1",
+    completionId: "T3.L8.G1",
     chestId: "ThaemineN1",
     modes: [
       {
@@ -639,7 +639,7 @@ export const goldTasks: GoldTask[] = [
   {
     name: "Thaemine Gate 2",
     taskName: "Thaemine",
-    completionId: "T3.L6.G2",
+    completionId: "T3.L8.G2",
     chestId: "ThaemineN2",
     modes: [
       {
@@ -659,7 +659,7 @@ export const goldTasks: GoldTask[] = [
   {
     name: "Thaemine Gate 3",
     taskName: "Thaemine",
-    completionId: "T3.L6.G3",
+    completionId: "T3.L8.G3",
     chestId: "ThaemineN3",
     modes: [
       {
@@ -679,7 +679,7 @@ export const goldTasks: GoldTask[] = [
   {
     name: "Thaemine Gate 4",
     taskName: "Thaemine G4",
-    completionId: "T3.L6.G4",
+    completionId: "T3.L9.G1",
     chestId: "ThaemineH4",
     modes: [
       {


### PR DESCRIPTION
This new flag, when set on **Remaining for the week**, will filter the gold planner based on tasks checked in the checklist to display gold that is still earnable before the weekly reset
![image](https://github.com/user-attachments/assets/494df4f1-13da-4167-aebb-482f197d45ba)
