### PR TITLE
Add tooltip with bound/unbound gold next to total

### DIFF
--- a/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.html
+++ b/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.html
@@ -118,7 +118,12 @@
                 </td>
               </tr>
               <tr class="total-row">
-                <td nzLeft class="total-cell">Total: <img src="./assets/icons/gold.png" class="gold-icon" alt="gold" />{{ display.grandTotal | number }}</td>
+                <td nzLeft class="total-cell">
+                  Total:
+                  <img src="./assets/icons/gold.png" class="gold-icon" alt="gold" />
+                  {{ display.grandTotal | number }}
+                  <i nz-icon nzType="message" nzTheme="outline" nz-tooltip [nzTooltipOverlayStyle]="{'max-width': '180px'}" nzTooltipTitle="{{ display.unboundGold | number }} Unbound Gold {{ display.boundGold | number }} Bound Gold" class="info-icon"></i>
+                </td>
                 <td class="total-cell" *ngFor="let row of display.total"><img src="./assets/icons/gold.png" class="gold-icon" alt="gold" />{{ row | number }}</td>
               </tr>
             </tbody>

--- a/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.ts
+++ b/apps/client/src/app/pages/gold-planner/gold-planner/gold-planner.component.ts
@@ -47,6 +47,8 @@ interface GoldPlannerDisplay {
   raidModesForGoldPlanner: Record<string, string>;
   total: number[];
   grandTotal: number;
+  boundGold: number;
+  unboundGold: number;
   plannerLines: PlannerLine[]
 }
 
@@ -260,6 +262,9 @@ export class GoldPlannerComponent {
         };
       }, {});
 
+      let unboundGold = 0;
+      let boundGold = 0;
+
       const total = chestsData
         .filter(row => row.task && row.line && row.line.gate)
         .reverse()
@@ -268,6 +273,13 @@ export class GoldPlannerComponent {
           goldDetails.forEach((flag, i) => {
             if (!flag.hide) {
               if (flag.takingGold) {
+                if (flag.runningMode === 'Solo') {
+                  boundGold += flag.goldReward
+                }
+                else {
+                  unboundGold += flag.goldReward
+                }
+
                 acc[i] += flag.goldReward
               }
 
@@ -290,6 +302,8 @@ export class GoldPlannerComponent {
         tracking,
         raidModesForGoldPlanner,
         grandTotal: total.reduce((acc, v) => acc + v, 0),
+        boundGold,
+        unboundGold,
         chaos,
         other,
         plannerLines


### PR DESCRIPTION
Provides a tooltip by the total on the gold planner that shows the bound/unbound gold. Solo raids provide bound gold, group raids provide unbound gold.

![tooltip](https://github.com/user-attachments/assets/a7c2929f-3d98-4591-b994-b21cd986a131)
