### PR TITLE
Track gold in checklist

### DIFF
--- a/apps/client/src/app/pages/checklist/checklist.module.ts
+++ b/apps/client/src/app/pages/checklist/checklist.module.ts
@@ -15,6 +15,7 @@ import { NzSwitchModule } from "ng-zorro-antd/switch";
 import { NzStatisticModule } from "ng-zorro-antd/statistic";
 import { NzGridModule } from "ng-zorro-antd/grid";
 import { NzDividerModule } from "ng-zorro-antd/divider";
+import { NzAlertModule } from "ng-zorro-antd/alert";
 
 const routes = [{
   path: "",
@@ -43,7 +44,8 @@ const routes = [{
     NzSwitchModule,
     NzStatisticModule,
     NzGridModule,
-    NzDividerModule
+    NzDividerModule,
+    NzAlertModule
   ]
 })
 export class ChecklistModule {

--- a/apps/client/src/app/pages/checklist/checklist/checklist.component.html
+++ b/apps/client/src/app/pages/checklist/checklist/checklist.component.html
@@ -5,8 +5,13 @@
     <br>
     <label nz-checkbox [ngModel]="forceShowHiddenCharacter$ | async" (ngModelChange)="forceShowHiddenCharacter$.next($event)"></label>
     Show your hidden characters
-    <i nz-icon nzType="info-circle" nzTheme="outline" nz-tooltip nzTooltipTitle="Only resets after 3 days"></i>
+    <i nz-icon nzType="info-circle" nzTheme="outline" nz-tooltip nzTooltipTitle="Only resets after 3 days"></i>   
   </ng-template>
+  <nz-page-header-content>
+    <nz-alert nzType="info" nzShowIcon="true" [nzDescription]="descriptionTpl">
+      <ng-template #descriptionTpl>New feature: you can see in the checklist which raid is giving you gold if you configure the <a class="header-link" routerLink="/gold-planner">Gold Planner</a></ng-template>
+    </nz-alert>
+  </nz-page-header-content>
 
   <nz-page-header-extra>
     <div class="countdowns-container">

--- a/apps/client/src/app/pages/checklist/checklist/checklist.component.html
+++ b/apps/client/src/app/pages/checklist/checklist/checklist.component.html
@@ -175,6 +175,7 @@
                               [class.weekly]="row.task.frequency === TaskFrequency.WEEKLY">
                             <ng-container *ngIf="row.completionData[i].tracked && roster[i].ilvl >= row.task.minIlvl && roster[i].ilvl < row.task.maxIlvl">
                               <div class="counter">
+                                <img *ngIf="row.completionData[i].takingGold" src="./assets/icons/gold.png" class="gold-icon" alt="gold" />
                                 <div>
                                   <button nz-button
                                           nzSize="small"

--- a/apps/client/src/app/pages/checklist/checklist/checklist.component.less
+++ b/apps/client/src/app/pages/checklist/checklist/checklist.component.less
@@ -291,3 +291,10 @@ table {
 .all-tasks {
   margin-bottom: 10px;
 }
+
+.gold-icon {
+  width: 24px;
+  height: 24px;
+  position: absolute;
+  left: 5px;
+}

--- a/apps/client/src/app/pages/checklist/checklist/checklist.component.less
+++ b/apps/client/src/app/pages/checklist/checklist/checklist.component.less
@@ -298,3 +298,9 @@ table {
   position: absolute;
   left: 5px;
 }
+
+.header-link {
+  font-weight: bold;
+  text-decoration: underline;
+  color: rgba(255, 255, 255, 0.85);
+}

--- a/apps/client/src/app/pages/gold-planner/gold-task.ts
+++ b/apps/client/src/app/pages/gold-planner/gold-task.ts
@@ -16,7 +16,7 @@ export interface Gate {
 
 export interface GoldTask {
   name: string;
-  taskName?: string;
+  taskName: string;
   gates: Gate[]
 }
 


### PR DESCRIPTION
When you configure the gold planner, you now see which raid gives you gold in the checklist
![image](https://github.com/user-attachments/assets/bfd2581d-5b6e-4599-86d7-83e8a03021bf)

I added an info on top of the checklist to promote that new feature. I will remove it in some time
![image](https://github.com/user-attachments/assets/c1d4739a-7017-40a1-93d4-920528fa9418)
